### PR TITLE
Dodaj widok wszystkich kortów

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,6 +42,41 @@ def overlay_kort(kort_id):
     )
 
 
+@app.route("/kort/all")
+def overlay_all():
+    """Renderuje widok z czterema kortami rozmieszczonymi w rogach."""
+    with open(CONFIG_PATH) as f:
+        overlay_config = json.load(f)
+
+    corner_positions = [
+        {"name": "top-left", "style": "top: 0; left: 0;"},
+        {"name": "top-right", "style": "top: 0; right: 0;"},
+        {"name": "bottom-left", "style": "bottom: 0; left: 0;"},
+        {"name": "bottom-right", "style": "bottom: 0; right: 0;"},
+    ]
+
+    overlays = []
+    sorted_overlays = sorted(
+        OVERLAY_LINKS.items(),
+        key=lambda item: int(item[0]) if str(item[0]).isdigit() else item[0]
+    )
+
+    for (kort_id, data), position in zip(sorted_overlays, corner_positions):
+        overlays.append(
+            {
+                "id": kort_id,
+                "overlay": data["overlay"],
+                "position": position,
+            }
+        )
+
+    return render_template(
+        "kort_all.html",
+        overlays=overlays,
+        config=overlay_config,
+    )
+
+
 @app.route("/config", methods=["GET", "POST"])
 def config():
     if request.method == "POST":

--- a/templates/kort_all.html
+++ b/templates/kort_all.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <title>Wszystkie korty</title>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      background: #0b0b0b;
+      color: #ffffff;
+      font-family: sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      overflow: hidden;
+    }
+
+    .stage {
+      position: relative;
+      width: 1920px;
+      height: 1080px;
+      background: transparent;
+      overflow: hidden;
+    }
+
+    .kort-container {
+      position: absolute;
+      width: {{ config.view_width * config.display_scale }}px;
+      height: {{ config.view_height * config.display_scale }}px;
+      overflow: hidden;
+      border-radius: 12px;
+      box-shadow: 0 0 12px rgba(0, 0, 0, 0.6);
+      background: rgba(0, 0, 0, 0.45);
+    }
+
+    .kort-frame {
+      width: 1920px;
+      height: 1080px;
+      transform: scale({{ config.display_scale }});
+      transform-origin: bottom left;
+      position: absolute;
+      left: {{ config.left_offset }}px;
+      bottom: 0;
+      border: none;
+    }
+
+    .kort-label {
+      font-size: 16px;
+      font-weight: 700;
+      text-shadow: 1px 1px 2px #000;
+      background: rgba(0, 0, 0, 0.65);
+      padding: 4px 10px;
+      border-radius: 6px;
+    }
+  </style>
+</head>
+<body>
+  <div class="stage">
+    {% for kort in overlays %}
+      <div class="kort-container" style="{{ kort.position.style }}" data-position="{{ kort.position.name }}">
+        <iframe class="kort-frame" src="{{ kort.overlay }}" title="Kort {{ kort.id }}"></iframe>
+        <div class="kort-label"
+             style="position: absolute;
+                    {% if config.label_position == 'top-left' %}
+                      top: 6px; left: 8px;
+                    {% elif config.label_position == 'top-right' %}
+                      top: 6px; right: 8px;
+                    {% elif config.label_position == 'bottom-left' %}
+                      bottom: 6px; left: 8px;
+                    {% elif config.label_position == 'bottom-right' %}
+                      bottom: 6px; right: 8px;
+                    {% elif config.label_position == 'top-center' %}
+                      top: 6px; left: 50%; transform: translateX(-50%);
+                    {% elif config.label_position == 'bottom-center' %}
+                      bottom: 6px; left: 50%; transform: translateX(-50%);
+                    {% endif %}">
+          Kort {{ kort.id }}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- dodano trasę `/kort/all`, która wczytuje bieżący `overlay_config.json` i przekazuje dane wszystkich kortów wraz z pozycjami
- przygotowano szablon `kort_all.html` z pętlą Jinja2 i stylami rozmieszczającymi cztery nakładki w rogach ekranu

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68c9aeb15678832ab773348eb7a43741