### PR TITLE
Add per-corner overlay configuration and live preview

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, request
 from flask_cors import CORS
+import copy
 import json
 import os
 
@@ -8,6 +9,184 @@ CORS(app)
 
 LINKS_PATH = "overlay_links.json"
 CONFIG_PATH = "overlay_config.json"
+
+CORNERS = ["top_left", "top_right", "bottom_left", "bottom_right"]
+
+CORNER_POSITION_STYLES = {
+    "top_left": {"name": "top-left", "style": "top: 0; left: 0;"},
+    "top_right": {"name": "top-right", "style": "top: 0; right: 0;"},
+    "bottom_left": {"name": "bottom-left", "style": "bottom: 0; left: 0;"},
+    "bottom_right": {"name": "bottom-right", "style": "bottom: 0; right: 0;"},
+}
+
+CORNER_LABELS = {
+    "top_left": "Lewy górny narożnik",
+    "top_right": "Prawy górny narożnik",
+    "bottom_left": "Lewy dolny narożnik",
+    "bottom_right": "Prawy dolny narożnik",
+}
+
+DEFAULT_BASE_CONFIG = {
+    "view_width": 690,
+    "view_height": 150,
+    "display_scale": 0.8,
+    "left_offset": -30,
+    "label_position": "top-left",
+}
+
+
+def as_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return default
+
+
+def as_float(value, default):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def get_default_corner_config(corner):
+    label_position = CORNER_POSITION_STYLES[corner]["name"]
+    return {
+        "view_width": DEFAULT_BASE_CONFIG["view_width"],
+        "view_height": DEFAULT_BASE_CONFIG["view_height"],
+        "display_scale": DEFAULT_BASE_CONFIG["display_scale"],
+        "offset_x": DEFAULT_BASE_CONFIG["left_offset"],
+        "offset_y": 0,
+        "label": {
+            "position": label_position,
+            "offset_x": 8,
+            "offset_y": 6,
+        },
+    }
+
+
+def merge_corner_config(default_corner, override):
+    result = copy.deepcopy(default_corner)
+    if not override:
+        return result
+
+    for key, value in override.items():
+        if key == "label":
+            label_override = value or {}
+            result_label = result.setdefault("label", {})
+            for label_key, label_value in label_override.items():
+                if label_value is not None:
+                    result_label[label_key] = label_value
+        elif value is not None:
+            result[key] = value
+
+    return result
+
+
+def normalize_corner_types(corner):
+    corner["view_width"] = as_int(corner.get("view_width"), DEFAULT_BASE_CONFIG["view_width"])
+    corner["view_height"] = as_int(corner.get("view_height"), DEFAULT_BASE_CONFIG["view_height"])
+    corner["display_scale"] = as_float(corner.get("display_scale"), DEFAULT_BASE_CONFIG["display_scale"])
+    corner["offset_x"] = as_int(corner.get("offset_x"), DEFAULT_BASE_CONFIG["left_offset"])
+    corner["offset_y"] = as_int(corner.get("offset_y"), 0)
+
+    label_defaults = {
+        "position": corner.get("label", {}).get("position", "top-left"),
+        "offset_x": 8,
+        "offset_y": 6,
+    }
+
+    label = corner.setdefault("label", {})
+    label["position"] = label.get("position", label_defaults["position"])
+    label["offset_x"] = as_int(label.get("offset_x"), label_defaults["offset_x"])
+    label["offset_y"] = as_int(label.get("offset_y"), label_defaults["offset_y"])
+
+    return corner
+
+
+def ensure_config_structure(config):
+    config = dict(config or {})
+
+    for key, default_value in DEFAULT_BASE_CONFIG.items():
+        config[key] = config.get(key, default_value)
+
+    config["view_width"] = as_int(config.get("view_width"), DEFAULT_BASE_CONFIG["view_width"])
+    config["view_height"] = as_int(config.get("view_height"), DEFAULT_BASE_CONFIG["view_height"])
+    config["display_scale"] = as_float(config.get("display_scale"), DEFAULT_BASE_CONFIG["display_scale"])
+    config["left_offset"] = as_int(config.get("left_offset"), DEFAULT_BASE_CONFIG["left_offset"])
+    config["label_position"] = config.get("label_position", DEFAULT_BASE_CONFIG["label_position"])
+
+    existing_kort_all = config.get("kort_all") or {}
+    ensured_kort_all = {}
+
+    top_left_base = {
+        "view_width": config["view_width"],
+        "view_height": config["view_height"],
+        "display_scale": config["display_scale"],
+        "offset_x": config["left_offset"],
+        "offset_y": 0,
+        "label": {
+            "position": config["label_position"],
+            "offset_x": 8,
+            "offset_y": 6,
+        },
+    }
+
+    for corner in CORNERS:
+        default_corner = get_default_corner_config(corner)
+        if corner == "top_left":
+            default_corner = merge_corner_config(default_corner, top_left_base)
+
+        corner_override = existing_kort_all.get(corner, {})
+        merged = merge_corner_config(default_corner, corner_override)
+        ensured_kort_all[corner] = normalize_corner_types(merged)
+
+    config["kort_all"] = ensured_kort_all
+
+    return config
+
+
+def load_config():
+    if not os.path.exists(CONFIG_PATH):
+        return ensure_config_structure(dict(DEFAULT_BASE_CONFIG))
+
+    with open(CONFIG_PATH) as f:
+        raw_config = json.load(f)
+
+    return ensure_config_structure(raw_config)
+
+
+def save_config(config):
+    prepared = ensure_config_structure(config)
+    with open(CONFIG_PATH, "w") as f:
+        json.dump(prepared, f, indent=2)
+    return prepared
+
+
+def build_label_style(label_config):
+    position = (label_config or {}).get("position", "top-left")
+    offset_x = as_int((label_config or {}).get("offset_x"), 0)
+    offset_y = as_int((label_config or {}).get("offset_y"), 0)
+
+    style_parts = ["position: absolute;"]
+
+    if "top" in position:
+        style_parts.append(f"top: {offset_y}px;")
+    else:
+        style_parts.append(f"bottom: {offset_y}px;")
+
+    if "center" in position:
+        style_parts.append(f"left: calc(50% + {offset_x}px);")
+        style_parts.append("transform: translateX(-50%);")
+    elif "right" in position:
+        style_parts.append(f"right: {offset_x}px;")
+    else:
+        style_parts.append(f"left: {offset_x}px;")
+
+    return " ".join(style_parts)
 
 # Stałe linki do overlayów
 with open(LINKS_PATH) as f:
@@ -27,8 +206,9 @@ def overlay_kort(kort_id):
         return f"Nieznany kort {kort_id}", 404
 
     # HOT reload konfiguracji przy każdym żądaniu
-    with open(CONFIG_PATH) as f:
-        overlay_config = json.load(f)
+    overlay_config = load_config()
+    mini_config = overlay_config["kort_all"].get("top_left", get_default_corner_config("top_left"))
+    mini_label_style = build_label_style(mini_config.get("label"))
 
     main_overlay = OVERLAY_LINKS[kort_id]["overlay"]
     mini = [(k, v["overlay"]) for k, v in OVERLAY_LINKS.items() if k != kort_id]
@@ -38,22 +218,16 @@ def overlay_kort(kort_id):
         kort_id=kort_id,
         main_overlay=main_overlay,
         mini_overlays=mini,
-        config=overlay_config
+        config=overlay_config,
+        mini_config=mini_config,
+        mini_label_style=mini_label_style,
     )
 
 
 @app.route("/kort/all")
 def overlay_all():
     """Renderuje widok z czterema kortami rozmieszczonymi w rogach."""
-    with open(CONFIG_PATH) as f:
-        overlay_config = json.load(f)
-
-    corner_positions = [
-        {"name": "top-left", "style": "top: 0; left: 0;"},
-        {"name": "top-right", "style": "top: 0; right: 0;"},
-        {"name": "bottom-left", "style": "bottom: 0; left: 0;"},
-        {"name": "bottom-right", "style": "bottom: 0; right: 0;"},
-    ]
+    overlay_config = load_config()
 
     overlays = []
     sorted_overlays = sorted(
@@ -61,12 +235,16 @@ def overlay_all():
         key=lambda item: int(item[0]) if str(item[0]).isdigit() else item[0]
     )
 
-    for (kort_id, data), position in zip(sorted_overlays, corner_positions):
+    for (kort_id, data), corner_key in zip(sorted_overlays, CORNERS):
+        corner_config = overlay_config["kort_all"].get(corner_key, get_default_corner_config(corner_key))
         overlays.append(
             {
                 "id": kort_id,
                 "overlay": data["overlay"],
-                "position": position,
+                "position": CORNER_POSITION_STYLES[corner_key],
+                "corner_key": corner_key,
+                "config": corner_config,
+                "label_style": build_label_style(corner_config.get("label")),
             }
         )
 
@@ -79,23 +257,56 @@ def overlay_all():
 
 @app.route("/config", methods=["GET", "POST"])
 def config():
+    current_config = load_config()
+
     if request.method == "POST":
+        form = request.form
+
         data = {
-            "view_width": int(request.form["view_width"]),
-            "view_height": int(request.form["view_height"]),
-            "display_scale": float(request.form["display_scale"]),
-            "left_offset": int(request.form["left_offset"]),
-            "label_position": request.form["label_position"]
-
+            "view_width": as_int(form.get("view_width", current_config["view_width"]), current_config["view_width"]),
+            "view_height": as_int(form.get("view_height", current_config["view_height"]), current_config["view_height"]),
+            "display_scale": as_float(form.get("display_scale", current_config["display_scale"]), current_config["display_scale"]),
+            "left_offset": as_int(form.get("left_offset", current_config["left_offset"]), current_config["left_offset"]),
+            "label_position": form.get("label_position", current_config["label_position"]),
         }
-        with open(CONFIG_PATH, "w") as f:
-            json.dump(data, f, indent=2)
-        return render_template("config.html", config=data)
 
-    # GET – pokaż aktualny config
-    with open(CONFIG_PATH) as f:
-        data = json.load(f)
-    return render_template("config.html", config=data)
+        kort_all = {}
+        for corner in CORNERS:
+            existing_corner = current_config["kort_all"].get(corner, get_default_corner_config(corner))
+            prefix = f"kort_all[{corner}]"
+            label_prefix = f"{prefix}[label]"
+
+            kort_all[corner] = {
+                "view_width": as_int(form.get(f"{prefix}[view_width]", existing_corner["view_width"]), existing_corner["view_width"]),
+                "view_height": as_int(form.get(f"{prefix}[view_height]", existing_corner["view_height"]), existing_corner["view_height"]),
+                "display_scale": as_float(form.get(f"{prefix}[display_scale]", existing_corner["display_scale"]), existing_corner["display_scale"]),
+                "offset_x": as_int(form.get(f"{prefix}[offset_x]", existing_corner["offset_x"]), existing_corner["offset_x"]),
+                "offset_y": as_int(form.get(f"{prefix}[offset_y]", existing_corner["offset_y"]), existing_corner["offset_y"]),
+                "label": {
+                    "position": form.get(f"{label_prefix}[position]", existing_corner["label"]["position"]),
+                    "offset_x": as_int(form.get(f"{label_prefix}[offset_x]", existing_corner["label"]["offset_x"]), existing_corner["label"]["offset_x"]),
+                    "offset_y": as_int(form.get(f"{label_prefix}[offset_y]", existing_corner["label"]["offset_y"]), existing_corner["label"]["offset_y"]),
+                },
+            }
+
+        data["kort_all"] = kort_all
+        saved_config = save_config(data)
+
+        return render_template(
+            "config.html",
+            config=saved_config,
+            corners=CORNERS,
+            corner_labels=CORNER_LABELS,
+            corner_positions=CORNER_POSITION_STYLES,
+        )
+
+    return render_template(
+        "config.html",
+        config=current_config,
+        corners=CORNERS,
+        corner_labels=CORNER_LABELS,
+        corner_positions=CORNER_POSITION_STYLES,
+    )
 
 
 if __name__ == "__main__":

--- a/overlay_config.json
+++ b/overlay_config.json
@@ -3,5 +3,55 @@
   "view_height": 150,
   "display_scale": 0.8,
   "left_offset": -30,
-  "label_position": "top-left"
+  "label_position": "top-left",
+  "kort_all": {
+    "top_left": {
+      "view_width": 690,
+      "view_height": 150,
+      "display_scale": 0.8,
+      "offset_x": -30,
+      "offset_y": 0,
+      "label": {
+        "position": "top-left",
+        "offset_x": 8,
+        "offset_y": 6
+      }
+    },
+    "top_right": {
+      "view_width": 690,
+      "view_height": 150,
+      "display_scale": 0.8,
+      "offset_x": -30,
+      "offset_y": 0,
+      "label": {
+        "position": "top-right",
+        "offset_x": 8,
+        "offset_y": 6
+      }
+    },
+    "bottom_left": {
+      "view_width": 690,
+      "view_height": 150,
+      "display_scale": 0.8,
+      "offset_x": -30,
+      "offset_y": 0,
+      "label": {
+        "position": "bottom-left",
+        "offset_x": 8,
+        "offset_y": 6
+      }
+    },
+    "bottom_right": {
+      "view_width": 690,
+      "view_height": 150,
+      "display_scale": 0.8,
+      "offset_x": -30,
+      "offset_y": 0,
+      "label": {
+        "position": "bottom-right",
+        "offset_x": 8,
+        "offset_y": 6
+      }
+    }
+  }
 }

--- a/templates/config.html
+++ b/templates/config.html
@@ -5,45 +5,256 @@
   <title>Konfiguracja Overlay</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body class="bg-gray-900 text-white min-h-screen flex items-center justify-center">
-  <form method="post" class="bg-gray-800 p-8 rounded shadow-md space-y-6 w-full max-w-md">
-    <h1 class="text-2xl font-bold mb-4">⚙️ Konfiguracja wycinków</h1>
+<body class="bg-gray-900 text-white min-h-screen">
+  <main class="max-w-6xl mx-auto py-10 px-4 space-y-10">
+    <form id="config-form" method="post" class="bg-gray-800/80 backdrop-blur rounded-2xl shadow-xl border border-gray-700/60 w-full p-8 space-y-8">
+      <header class="space-y-2">
+        <h1 class="text-3xl font-semibold flex items-center gap-3">⚙️ Konfiguracja wycinków</h1>
+        <p class="text-sm text-gray-300">Dostosuj parametry widoków pojedynczych i wszystkich kortów. Zmiany zapisują się w pliku konfiguracyjnym.</p>
+      </header>
 
-    <label class="block">
-      <span>📐 Szerokość wycinka (px)</span>
-      <input type="number" name="view_width" value="{{ config.view_width }}" class="w-full p-2 rounded bg-gray-700 text-white" />
-    </label>
+      <section class="space-y-4">
+        <h2 class="text-xl font-semibold flex items-center gap-2">🧭 Ustawienia ogólne</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <label class="block text-sm space-y-1">
+            <span class="text-gray-200">📐 Szerokość wycinka (px)</span>
+            <input type="number" name="view_width" value="{{ config.view_width }}" min="1" step="1" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+          </label>
+          <label class="block text-sm space-y-1">
+            <span class="text-gray-200">📏 Wysokość wycinka (px)</span>
+            <input type="number" name="view_height" value="{{ config.view_height }}" min="1" step="1" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+          </label>
+          <label class="block text-sm space-y-1">
+            <span class="text-gray-200">🔍 Skala wyświetlania</span>
+            <input type="number" step="0.05" min="0" name="display_scale" value="{{ config.display_scale }}" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+          </label>
+          <label class="block text-sm space-y-1">
+            <span class="text-gray-200">↔️ Przesunięcie w lewo (px)</span>
+            <input type="number" name="left_offset" value="{{ config.left_offset }}" step="1" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+          </label>
+          <label class="block text-sm space-y-1 md:col-span-2">
+            <span class="text-gray-200">📍 Pozycja napisu „Kort X”</span>
+            <select name="label_position" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+              {% for pos in ["top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"] %}
+                <option value="{{ pos }}" {% if config.label_position == pos %}selected{% endif %}>{{ pos|replace('-', ' ')|title }}</option>
+              {% endfor %}
+            </select>
+          </label>
+        </div>
+      </section>
 
-    <label class="block">
-      <span>📏 Wysokość wycinka (px)</span>
-      <input type="number" name="view_height" value="{{ config.view_height }}" class="w-full p-2 rounded bg-gray-700 text-white" />
-    </label>
+      <section class="space-y-4">
+        <h2 class="text-xl font-semibold flex items-center gap-2">🎯 Ustawienia narożników</h2>
+        <p class="text-sm text-gray-300">Każdy narożnik może mieć własny rozmiar wycinka, skalę, offset oraz ustawienia etykiety.</p>
+        <div class="space-y-6">
+          {% for corner in corners %}
+            {% set corner_config = config.kort_all[corner] %}
+            <fieldset class="border border-gray-700/60 rounded-xl p-6 bg-gray-900/40 space-y-4">
+              <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ corner_labels[corner] }}</legend>
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <label class="block text-sm space-y-1">
+                  <span class="text-gray-200">📐 Szerokość (px)</span>
+                  <input type="number" name="kort_all[{{ corner }}][view_width]" value="{{ corner_config.view_width }}" min="1" step="1" data-corner="{{ corner }}" data-field="view_width" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                </label>
+                <label class="block text-sm space-y-1">
+                  <span class="text-gray-200">📏 Wysokość (px)</span>
+                  <input type="number" name="kort_all[{{ corner }}][view_height]" value="{{ corner_config.view_height }}" min="1" step="1" data-corner="{{ corner }}" data-field="view_height" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                </label>
+                <label class="block text-sm space-y-1">
+                  <span class="text-gray-200">🔍 Skala</span>
+                  <input type="number" name="kort_all[{{ corner }}][display_scale]" value="{{ corner_config.display_scale }}" step="0.05" min="0" data-corner="{{ corner }}" data-field="display_scale" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                </label>
+                <label class="block text-sm space-y-1">
+                  <span class="text-gray-200">↔️ Offset X (px)</span>
+                  <input type="number" name="kort_all[{{ corner }}][offset_x]" value="{{ corner_config.offset_x }}" step="1" data-corner="{{ corner }}" data-field="offset_x" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                </label>
+                <label class="block text-sm space-y-1 md:col-span-2">
+                  <span class="text-gray-200">↕️ Offset Y (px)</span>
+                  <input type="number" name="kort_all[{{ corner }}][offset_y]" value="{{ corner_config.offset_y }}" step="1" data-corner="{{ corner }}" data-field="offset_y" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                </label>
+                <div class="md:col-span-2 bg-gray-800/40 border border-gray-700/50 rounded-lg p-4 space-y-3">
+                  <h3 class="text-sm font-semibold uppercase tracking-widest text-gray-300">Etykieta</h3>
+                  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <label class="block text-sm space-y-1">
+                      <span class="text-gray-200">📍 Pozycja</span>
+                      <select name="kort_all[{{ corner }}][label][position]" data-corner="{{ corner }}" data-label-field="position" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                        {% for pos in ["top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"] %}
+                          <option value="{{ pos }}" {% if corner_config.label.position == pos %}selected{% endif %}>{{ pos|replace('-', ' ')|title }}</option>
+                        {% endfor %}
+                      </select>
+                    </label>
+                    <label class="block text-sm space-y-1">
+                      <span class="text-gray-200">↔️ Offset etykiety X (px)</span>
+                      <input type="number" name="kort_all[{{ corner }}][label][offset_x]" value="{{ corner_config.label.offset_x }}" step="1" data-corner="{{ corner }}" data-label-field="offset_x" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                    </label>
+                    <label class="block text-sm space-y-1">
+                      <span class="text-gray-200">↕️ Offset etykiety Y (px)</span>
+                      <input type="number" name="kort_all[{{ corner }}][label][offset_y]" value="{{ corner_config.label.offset_y }}" step="1" data-corner="{{ corner }}" data-label-field="offset_y" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          {% endfor %}
+        </div>
+      </section>
 
-    <label class="block">
-      <span>🔍 Skala wyświetlania</span>
-      <input type="number" step="0.1" name="display_scale" value="{{ config.display_scale }}" class="w-full p-2 rounded bg-gray-700 text-white" />
-    </label>
+      <div class="flex flex-wrap justify-between items-center gap-4 pt-4">
+        <button type="submit" class="bg-emerald-600 hover:bg-emerald-500 transition-colors px-6 py-2 rounded-lg font-semibold">💾 Zapisz</button>
+        <a href="/" class="text-gray-300 underline hover:text-white">← Wróć</a>
+      </div>
+    </form>
 
-    <label class="block">
-      <span>↔️ Przesunięcie w lewo (px)</span>
-      <input type="number" name="left_offset" value="{{ config.left_offset }}" class="w-full p-2 rounded bg-gray-700 text-white" />
-    </label>
+    <section class="w-full bg-gray-800/80 border border-gray-700/60 rounded-2xl p-8 space-y-4 shadow-lg">
+      <div class="flex items-center gap-2">
+        <h2 class="text-xl font-semibold">👀 Podgląd ustawień</h2>
+        <span class="text-xs uppercase tracking-widest text-gray-400">Aktualizuje się w czasie rzeczywistym</span>
+      </div>
+      <p class="text-sm text-gray-300">Podgląd reprezentuje scenę o rozdzielczości 1920×1080. Zmiany w formularzu natychmiast aktualizują rozmiary i pozycje placeholderów.</p>
+      <div class="overflow-auto rounded-xl border border-gray-700/80 bg-gray-900/80 p-4">
+        <div id="preview-stage" class="relative mx-auto" style="width: 1920px; height: 1080px; transform: scale(0.5); transform-origin: top left;">
+          {% for corner in corners %}
+            {% set corner_config = config.kort_all[corner] %}
+            <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_positions[corner].style }} width: {{ corner_config.view_width * corner_config.display_scale }}px; height: {{ corner_config.view_height * corner_config.display_scale }}px;">
+              <div class="preview-overlay absolute inset-0 bg-gradient-to-br from-emerald-400/10 to-transparent pointer-events-none"></div>
+              <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
+              <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ corner_labels[corner] }}</span>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+  </main>
 
-    <label class="block">
-      <span>📍 Pozycja napisu „Kort X”</span>
-      <select name="label_position" class="w-full p-2 rounded bg-gray-700 text-white">
-        {% for pos in ["top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"] %}
-          <option value="{{ pos }}" {% if config.label_position == pos %}selected{% endif %}>
-            {{ pos.replace('-', ' ').capitalize() }}
-          </option>
-        {% endfor %}
-      </select>
-    </label>
+  <script>
+    (function () {
+      const form = document.getElementById('config-form');
+      const previewStage = document.getElementById('preview-stage');
+      if (!form || !previewStage) {
+        return;
+      }
 
-    <div class="flex justify-between pt-4">
-      <button type="submit" class="bg-green-600 hover:bg-green-500 px-4 py-2 rounded">💾 Zapisz</button>
-      <a href="/" class="text-gray-300 underline">← Wróć</a>
-    </div>
-  </form>
+      const corners = {{ corners|tojson }};
+      const defaults = {{ config.kort_all|tojson }};
+      const cornerLabels = {{ corner_labels|tojson }};
+
+      function coerceNumber(value, fallback) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : fallback;
+      }
+
+      function parseFieldValue(field) {
+        if (field.type === 'number') {
+          if (field.value === '') {
+            return NaN;
+          }
+          const parsed = Number(field.value);
+          return Number.isFinite(parsed) ? parsed : NaN;
+        }
+        return field.value;
+      }
+
+      function readCornerConfig(corner) {
+        const base = defaults[corner] || {};
+        const baseLabel = base.label || {};
+        const result = {
+          view_width: coerceNumber(base.view_width, 0),
+          view_height: coerceNumber(base.view_height, 0),
+          display_scale: coerceNumber(base.display_scale, 0),
+          offset_x: coerceNumber(base.offset_x, 0),
+          offset_y: coerceNumber(base.offset_y, 0),
+          label: {
+            position: baseLabel.position || 'top-left',
+            offset_x: coerceNumber(baseLabel.offset_x, 0),
+            offset_y: coerceNumber(baseLabel.offset_y, 0),
+          },
+        };
+
+        const fields = form.querySelectorAll(`[data-corner="${corner}"]`);
+        fields.forEach((field) => {
+          const value = parseFieldValue(field);
+          if (field.dataset.field) {
+            if (typeof value === 'number') {
+              if (Number.isFinite(value)) {
+                result[field.dataset.field] = value;
+              }
+            } else if (value !== undefined && value !== null && value !== '') {
+              result[field.dataset.field] = value;
+            }
+          } else if (field.dataset.labelField) {
+            if (typeof value === 'number') {
+              if (Number.isFinite(value)) {
+                result.label[field.dataset.labelField] = value;
+              }
+            } else if (value) {
+              result.label[field.dataset.labelField] = value;
+            }
+          }
+        });
+
+        return result;
+      }
+
+      function applyLabelStyle(label, data) {
+        label.style.top = '';
+        label.style.bottom = '';
+        label.style.left = '';
+        label.style.right = '';
+        label.style.transform = '';
+
+        const position = data.label.position || 'top-left';
+        const offsetX = Number.isFinite(data.label.offset_x) ? data.label.offset_x : 0;
+        const offsetY = Number.isFinite(data.label.offset_y) ? data.label.offset_y : 0;
+
+        if (position.includes('top')) {
+          label.style.top = `${offsetY}px`;
+        } else {
+          label.style.bottom = `${offsetY}px`;
+        }
+
+        if (position.includes('center')) {
+          label.style.left = `calc(50% + ${offsetX}px)`;
+          label.style.transform = 'translateX(-50%)';
+        } else if (position.includes('right')) {
+          label.style.right = `${offsetX}px`;
+        } else {
+          label.style.left = `${offsetX}px`;
+        }
+      }
+
+      function updatePreview() {
+        corners.forEach((corner) => {
+          const card = previewStage.querySelector(`[data-corner="${corner}"]`);
+          if (!card) {
+            return;
+          }
+          const data = readCornerConfig(corner);
+          const width = data.view_width * data.display_scale;
+          const height = data.view_height * data.display_scale;
+
+          card.style.width = `${Math.max(width, 0)}px`;
+          card.style.height = `${Math.max(height, 0)}px`;
+
+          const frame = card.querySelector('[data-preview-frame]');
+          if (frame) {
+            frame.style.transform = `scale(${data.display_scale})`;
+            frame.style.transformOrigin = 'bottom left';
+            frame.style.left = `${data.offset_x}px`;
+            frame.style.bottom = `${data.offset_y}px`;
+          }
+
+          const label = card.querySelector('[data-preview-label]');
+          if (label) {
+            label.textContent = cornerLabels[corner] || 'Kort';
+            applyLabelStyle(label, data);
+          }
+        });
+      }
+
+      form.addEventListener('input', updatePreview);
+      form.addEventListener('change', updatePreview);
+      updatePreview();
+    })();
+  </script>
 </body>
 </html>

--- a/templates/kort.html
+++ b/templates/kort.html
@@ -55,8 +55,8 @@
   <div class="top-strip">
     {% for i, url in mini_overlays %}
       <div class="mini-overlay"
-           style="width: {{ config.view_width * config.display_scale }}px;
-                  height: {{ config.view_height * config.display_scale }}px;
+           style="width: {{ mini_config.view_width * mini_config.display_scale }}px;
+                  height: {{ mini_config.view_height * mini_config.display_scale }}px;
                   position: relative;
                   overflow: hidden;
                   border-radius: 8px;
@@ -69,32 +69,18 @@
           style="
             width: 1920px;
             height: 1080px;
-            transform: scale({{ config.display_scale }});
+            transform: scale({{ mini_config.display_scale }});
             transform-origin: bottom left;
             position: absolute;
-            left: {{ config.left_offset }}px;
-            bottom: 0;
+            left: {{ mini_config.offset_x }}px;
+            bottom: {{ mini_config.offset_y }}px;
             border: none;">
         </iframe>
 
         <!-- Etykieta kortu -->
-        <div class="kort-label"
-     style="position: absolute;
-            {% if config.label_position == 'top-left' %}
-              top: 4px; left: 6px;
-            {% elif config.label_position == 'top-right' %}
-              top: 4px; right: 6px;
-            {% elif config.label_position == 'bottom-left' %}
-              bottom: 4px; left: 6px;
-            {% elif config.label_position == 'bottom-right' %}
-              bottom: 4px; right: 6px;
-            {% elif config.label_position == 'top-center' %}
-              top: 4px; left: 50%; transform: translateX(-50%);
-            {% elif config.label_position == 'bottom-center' %}
-              bottom: 4px; left: 50%; transform: translateX(-50%);
-            {% endif %}">
-  Kort {{ i }}
-</div>
+        <div class="kort-label" style="{{ mini_label_style }}">
+          Kort {{ i }}
+        </div>
 
       </div>
     {% endfor %}

--- a/templates/kort_all.html
+++ b/templates/kort_all.html
@@ -28,8 +28,6 @@
 
     .kort-container {
       position: absolute;
-      width: {{ config.view_width * config.display_scale }}px;
-      height: {{ config.view_height * config.display_scale }}px;
       overflow: hidden;
       border-radius: 12px;
       box-shadow: 0 0 12px rgba(0, 0, 0, 0.6);
@@ -39,11 +37,7 @@
     .kort-frame {
       width: 1920px;
       height: 1080px;
-      transform: scale({{ config.display_scale }});
-      transform-origin: bottom left;
       position: absolute;
-      left: {{ config.left_offset }}px;
-      bottom: 0;
       border: none;
     }
 
@@ -60,23 +54,14 @@
 <body>
   <div class="stage">
     {% for kort in overlays %}
-      <div class="kort-container" style="{{ kort.position.style }}" data-position="{{ kort.position.name }}">
-        <iframe class="kort-frame" src="{{ kort.overlay }}" title="Kort {{ kort.id }}"></iframe>
-        <div class="kort-label"
-             style="position: absolute;
-                    {% if config.label_position == 'top-left' %}
-                      top: 6px; left: 8px;
-                    {% elif config.label_position == 'top-right' %}
-                      top: 6px; right: 8px;
-                    {% elif config.label_position == 'bottom-left' %}
-                      bottom: 6px; left: 8px;
-                    {% elif config.label_position == 'bottom-right' %}
-                      bottom: 6px; right: 8px;
-                    {% elif config.label_position == 'top-center' %}
-                      top: 6px; left: 50%; transform: translateX(-50%);
-                    {% elif config.label_position == 'bottom-center' %}
-                      bottom: 6px; left: 50%; transform: translateX(-50%);
-                    {% endif %}">
+      <div class="kort-container"
+           style="{{ kort.position.style }} width: {{ kort.config.view_width * kort.config.display_scale }}px; height: {{ kort.config.view_height * kort.config.display_scale }}px;"
+           data-position="{{ kort.position.name }}">
+        <iframe class="kort-frame"
+                src="{{ kort.overlay }}"
+                title="Kort {{ kort.id }}"
+                style="transform: scale({{ kort.config.display_scale }}); transform-origin: bottom left; left: {{ kort.config.offset_x }}px; bottom: {{ kort.config.offset_y }}px;"></iframe>
+        <div class="kort-label" style="{{ kort.label_style }}">
           Kort {{ kort.id }}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- introduce helpers that normalize and persist per-corner overlay settings and expose them to templates
- extend the configuration UI with nested fields for each corner plus a live preview to edit the new structure
- update overlay templates to consume the corner-specific sizing, offsets and label styles

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9b17bd448832a9d16b4a5a9493c66