### PR TITLE
Add overlay settings link on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,10 +8,13 @@
 <body class="bg-gray-900 text-white flex items-center justify-center min-h-screen">
   <div class="text-center space-y-6">
     <h1 class="text-3xl font-bold">Wybierz kort</h1>
-    <div class="space-x-4">
-      {% for i, link in links.items() %}
-      <a href="{{ link.control }}" class="px-6 py-3 bg-purple-600 hover:bg-purple-500 rounded text-white text-lg">Kort {{ i }}</a>
-      {% endfor %}
+    <div class="space-y-4">
+      <div class="flex flex-wrap justify-center gap-4">
+        {% for i, link in links.items() %}
+        <a href="{{ link.control }}" class="px-6 py-3 bg-purple-600 hover:bg-purple-500 rounded text-white text-lg">Kort {{ i }}</a>
+        {% endfor %}
+      </div>
+      <a href="{{ url_for('config') }}" class="inline-block px-6 py-3 bg-gray-700 hover:bg-gray-600 rounded text-white text-lg font-semibold">Ustawienia overlayu</a>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add a Tailwind-styled "Ustawienia overlayu" link below the court list on the landing page
- ensure the new link points to the config view and keeps the layout responsive via flex utilities

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b420ac6c832a9950e45333345c2a