### PR TITLE
Ensure config page always renders with full context

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,6 +188,17 @@ def build_label_style(label_config):
 
     return " ".join(style_parts)
 
+
+def render_config(config_dict):
+    return render_template(
+        "config.html",
+        config=config_dict,
+        corners=CORNERS,
+        corner_labels=CORNER_LABELS,
+        corner_positions=CORNER_POSITION_STYLES,
+    )
+
+
 # Stałe linki do overlayów
 with open(LINKS_PATH) as f:
     OVERLAY_LINKS = json.load(f)
@@ -292,21 +303,9 @@ def config():
         data["kort_all"] = kort_all
         saved_config = save_config(data)
 
-        return render_template(
-            "config.html",
-            config=saved_config,
-            corners=CORNERS,
-            corner_labels=CORNER_LABELS,
-            corner_positions=CORNER_POSITION_STYLES,
-        )
+        return render_config(saved_config)
 
-    return render_template(
-        "config.html",
-        config=current_config,
-        corners=CORNERS,
-        corner_labels=CORNER_LABELS,
-        corner_positions=CORNER_POSITION_STYLES,
-    )
+    return render_config(current_config)
 
 
 if __name__ == "__main__":

--- a/templates/config.html
+++ b/templates/config.html
@@ -134,9 +134,9 @@
         return;
       }
 
-      const corners = {{ corners|tojson }};
-      const defaults = {{ config.kort_all|tojson }};
-      const cornerLabels = {{ corner_labels|tojson }};
+      const corners = {{ corners|default([])|tojson }};
+      const defaults = {{ config.kort_all|default({})|tojson }};
+      const cornerLabels = {{ corner_labels|default({})|tojson }};
 
       function coerceNumber(value, fallback) {
         const parsed = Number(value);


### PR DESCRIPTION
## Summary
- add fallbacks before serializing config data in the config template
- centralize config.html rendering so both GET and POST share the same context

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68c9bf6b1a18832a87074681d7a3aa98