### PR TITLE
Handle missing kort_all in config template

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -54,7 +54,7 @@
         <p class="text-sm text-gray-300">Każdy narożnik może mieć własny rozmiar wycinka, skalę, offset oraz ustawienia etykiety.</p>
         <div class="space-y-6">
           {% for corner in corner_keys %}
-            {% set corner_config = config.kort_all.get(corner, {}) %}
+            {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
             <fieldset class="border border-gray-700/60 rounded-xl p-6 bg-gray-900/40 space-y-4">
               <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ corner_labels[corner] }}</legend>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -120,7 +120,7 @@
       <div id="preview-wrapper" class="overflow-hidden relative w-full rounded-xl border border-gray-700/80 bg-gray-900/80 p-4">
         <div id="preview-stage" class="relative" style="width: 1920px; height: 1080px;">
           {% for corner in corner_keys %}
-            {% set corner_config = config.kort_all.get(corner, {}) %}
+            {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
             <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_positions[corner].style }} width: {{ (corner_config.view_width | default(0)) * (corner_config.display_scale | default(0)) }}px; height: {{ (corner_config.view_height | default(0)) * (corner_config.display_scale | default(0)) }}px;">
               <div class="preview-overlay absolute inset-0 bg-gradient-to-br from-emerald-400/10 to-transparent pointer-events-none"></div>
               <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
@@ -142,7 +142,7 @@
       }
 
       const corners = {{ corner_keys|tojson }};
-      const defaults = {{ config.kort_all|default({})|tojson }};
+      const defaults = {{ config.get('kort_all', {})|tojson }};
       const cornerLabels = {{ corner_labels|default({})|tojson }};
 
       function coerceNumber(value, fallback) {


### PR DESCRIPTION
## Summary
- guard the config form and preview against missing `kort_all` sections
- serialize default corner data using a safe `config.get('kort_all', {})`

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68c9c83b176c832a88e10182f64fe3ac