### PR TITLE
Ensure safe corner label fallback in config template

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -55,8 +55,9 @@
         <div class="space-y-6">
           {% for corner in corner_keys %}
             {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
+            {% set corner_label = (corner_labels|default({})).get(corner, 'Kort') %}
             <fieldset class="border border-gray-700/60 rounded-xl p-6 bg-gray-900/40 space-y-4">
-              <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ (corner_labels|default({})).get(corner, 'Kort') }}</legend>
+              <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ corner_label }}</legend>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <label class="block text-sm space-y-1">
                   <span class="text-gray-200">📐 Szerokość (px)</span>
@@ -121,10 +122,11 @@
         <div id="preview-stage" class="relative" style="width: 1920px; height: 1080px;">
           {% for corner in corner_keys %}
             {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
+            {% set corner_label = (corner_labels|default({})).get(corner, 'Kort') %}
             <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_positions[corner].style }} width: {{ (corner_config.view_width | default(0)) * (corner_config.display_scale | default(0)) }}px; height: {{ (corner_config.view_height | default(0)) * (corner_config.display_scale | default(0)) }}px;">
               <div class="preview-overlay absolute inset-0 bg-gradient-to-br from-emerald-400/10 to-transparent pointer-events-none"></div>
               <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
-              <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ (corner_labels|default({})).get(corner, 'Kort') }}</span>
+              <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ corner_label }}</span>
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
## Summary
- set a reusable `corner_label` variable in the corner loops to fall back to "Kort" when labels are missing
- reuse the precomputed label in both the form legend and preview chip for consistency

## Testing
- python - <<'PY' … (render config template with and without corner labels)

------
https://chatgpt.com/codex/tasks/task_e_68ca7e1afeac832a87f9784ffda4e4d6