### PR TITLE
Ensure config template handles missing corner labels

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -50,6 +50,7 @@
 <body class="bg-gray-900 text-white min-h-screen">
   <main class="max-w-6xl mx-auto py-10 px-4 space-y-10">
     {% set corner_keys = corners if corners else ['top_left', 'top_right', 'bottom_left', 'bottom_right'] %}
+    {% set safe_corner_labels = corner_labels|default({}) %}
     <form id="config-form" method="post" class="bg-gray-800/80 backdrop-blur rounded-2xl shadow-xl border border-gray-700/60 w-full p-8 space-y-8">
       <header class="space-y-2">
         <h1 class="text-3xl font-semibold flex items-center gap-3">⚙️ Konfiguracja wycinków</h1>
@@ -94,7 +95,7 @@
             {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
             {% set label_config = (corner_config.get('label') or {}) %}
             <fieldset class="border border-gray-700/60 rounded-xl p-6 bg-gray-900/40 space-y-4">
-              <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ (corner_labels|default({})).get(corner, 'Kort') }}</legend>
+              <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ safe_corner_labels.get(corner, 'Kort') }}</legend>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <label class="block text-sm space-y-1">
                   <span class="text-gray-200">📐 Szerokość (px)</span>
@@ -167,7 +168,7 @@
                 <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_position.get('style', '') }} width: {{ (corner_config.view_width | default(0)) * (corner_config.display_scale | default(0)) }}px; height: {{ (corner_config.view_height | default(0)) * (corner_config.display_scale | default(0)) }}px;">
                   <div class="preview-overlay absolute inset-0 bg-gradient-to-br from-emerald-400/10 to-transparent pointer-events-none"></div>
                   <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
-                  <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ (corner_labels|default({})).get(corner, 'Kort') }}</span>
+                  <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ safe_corner_labels.get(corner, 'Kort') }}</span>
                 </div>
               {% endfor %}
             </div>
@@ -183,7 +184,7 @@
                 {% for corner in corner_keys %}
                   <div class="preview-mini-card" data-mini-card data-corner="{{ corner }}">
                     <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
-                    <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ (corner_labels|default({})).get(corner, 'Kort') }}</span>
+                    <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ safe_corner_labels.get(corner, 'Kort') }}</span>
                   </div>
                 {% endfor %}
               </div>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,15 @@ from pathlib import Path
 
 import pytest
 
-from main import CONFIG_PATH, CORNERS, CORNER_POSITION_STYLES, load_config, save_config
+from main import (
+    CONFIG_PATH,
+    CORNERS,
+    CORNER_POSITION_STYLES,
+    app,
+    load_config,
+    render_config,
+    save_config,
+)
 
 
 def test_get_config_renders_form_and_preview(client):
@@ -112,3 +120,30 @@ def test_kort_all_renders_all_courts_with_labels(client):
         assert f'data-position="{position}"' in html
     assert "Kort 1" in html and "Kort 4" in html
     assert "transform: scale(0.9);" in html
+
+
+def test_config_template_renders_with_full_context():
+    config = load_config()
+
+    with app.app_context():
+        html = render_config(config)
+
+    assert "Konfiguracja Overlay" in html
+    for corner in CORNERS:
+        assert f'data-corner="{corner}"' in html
+
+
+def test_config_template_handles_missing_corner_labels():
+    config = load_config()
+
+    with app.app_context():
+        template = app.jinja_env.get_template("config.html")
+        html = template.render(
+            config=config,
+            corners=CORNERS,
+            corner_positions=CORNER_POSITION_STYLES,
+        )
+
+    assert "Konfiguracja Overlay" in html
+    for corner in CORNERS:
+        assert f'data-corner="{corner}"' in html


### PR DESCRIPTION
## Summary
- guard config template corner labels with a default dictionary helper
- add regression tests covering config rendering with and without corner_labels in context

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca896074a4832a854ca9a1b5b0de80