### PR TITLE
Handle missing label config in config template

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -94,6 +94,9 @@
           {% for corner in corner_keys %}
             {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
             {% set label_config = (corner_config.get('label') or {}) %}
+            {% set label_position = label_config.get('position', 'top-left') %}
+            {% set label_offset_x = label_config.get('offset_x', 0) %}
+            {% set label_offset_y = label_config.get('offset_y', 0) %}
             <fieldset class="border border-gray-700/60 rounded-xl p-6 bg-gray-900/40 space-y-4">
               <legend class="px-2 text-lg font-semibold text-emerald-300 uppercase tracking-wider">{{ safe_corner_labels.get(corner, 'Kort') }}</legend>
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -124,17 +127,17 @@
                       <span class="text-gray-200">📍 Pozycja</span>
                       <select name="kort_all[{{ corner }}][label][position]" data-corner="{{ corner }}" data-label-field="position" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
                         {% for pos in ["top-left", "top-center", "top-right", "bottom-left", "bottom-center", "bottom-right"] %}
-                          <option value="{{ pos }}" {% if label_config.get('position', 'top-left') == pos %}selected{% endif %}>{{ pos|replace('-', ' ')|title }}</option>
+                          <option value="{{ pos }}" {% if label_position == pos %}selected{% endif %}>{{ pos|replace('-', ' ')|title }}</option>
                         {% endfor %}
                       </select>
                     </label>
                     <label class="block text-sm space-y-1">
                       <span class="text-gray-200">↔️ Offset etykiety X (px)</span>
-                      <input type="number" name="kort_all[{{ corner }}][label][offset_x]" value="{{ label_config.get('offset_x', 0) }}" step="1" data-corner="{{ corner }}" data-label-field="offset_x" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                      <input type="number" name="kort_all[{{ corner }}][label][offset_x]" value="{{ label_offset_x }}" step="1" data-corner="{{ corner }}" data-label-field="offset_x" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
                     </label>
                     <label class="block text-sm space-y-1">
                       <span class="text-gray-200">↕️ Offset etykiety Y (px)</span>
-                      <input type="number" name="kort_all[{{ corner }}][label][offset_y]" value="{{ label_config.get('offset_y', 0) }}" step="1" data-corner="{{ corner }}" data-label-field="offset_y" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
+                      <input type="number" name="kort_all[{{ corner }}][label][offset_y]" value="{{ label_offset_y }}" step="1" data-corner="{{ corner }}" data-label-field="offset_y" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500/60">
                     </label>
                   </div>
                 </div>
@@ -164,11 +167,14 @@
               {% for corner in corner_keys %}
                 {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
                 {% set label_config = (corner_config.get('label') or {}) %}
+                {% set label_position = label_config.get('position', 'top-left') %}
+                {% set label_offset_x = label_config.get('offset_x', 0) %}
+                {% set label_offset_y = label_config.get('offset_y', 0) %}
                 {% set corner_position = (corner_positions|default({})).get(corner, {}) %}
                 <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_position.get('style', '') }} width: {{ (corner_config.view_width | default(0)) * (corner_config.display_scale | default(0)) }}px; height: {{ (corner_config.view_height | default(0)) * (corner_config.display_scale | default(0)) }}px;">
                   <div class="preview-overlay absolute inset-0 bg-gradient-to-br from-emerald-400/10 to-transparent pointer-events-none"></div>
                   <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
-                  <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ safe_corner_labels.get(corner, 'Kort') }}</span>
+                  <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label data-label-position="{{ label_position }}" data-label-offset-x="{{ label_offset_x }}" data-label-offset-y="{{ label_offset_y }}">{{ safe_corner_labels.get(corner, 'Kort') }}</span>
                 </div>
               {% endfor %}
             </div>
@@ -182,9 +188,14 @@
               <div class="preview-main-frame"></div>
               <div class="preview-top-strip" data-preview-top-strip>
                 {% for corner in corner_keys %}
+                  {% set corner_config = (config.get('kort_all', {})).get(corner, {}) %}
+                  {% set label_config = (corner_config.get('label') or {}) %}
+                  {% set label_position = label_config.get('position', 'top-left') %}
+                  {% set label_offset_x = label_config.get('offset_x', 0) %}
+                  {% set label_offset_y = label_config.get('offset_y', 0) %}
                   <div class="preview-mini-card" data-mini-card data-corner="{{ corner }}">
                     <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
-                    <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label>{{ safe_corner_labels.get(corner, 'Kort') }}</span>
+                    <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label data-label-position="{{ label_position }}" data-label-offset-x="{{ label_offset_x }}" data-label-offset-y="{{ label_offset_y }}">{{ safe_corner_labels.get(corner, 'Kort') }}</span>
                   </div>
                 {% endfor %}
               </div>


### PR DESCRIPTION
## Summary
- reuse a shared `label_config` helper in the configuration form and preview
- provide defaulted label position and offset values for both rendering contexts
- expose label defaults as data attributes so previews initialise correctly when the label section is absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca89f8b308832ab8cfa9f5fb39d5b1