### PR TITLE
Add HTTP view tests for kort endpoints

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+@pytest.mark.parametrize("kort_id", ["1", "2"])
+def test_overlay_kort_existing(client, kort_id):
+    response = client.get(f"/kort/{kort_id}")
+    assert response.status_code == 200
+    html = response.data.decode()
+    assert '<iframe class="overlay-main"' in html
+    assert "Kort" in html
+    assert "top-strip" in html
+
+
+def test_overlay_all_view(client):
+    response = client.get("/kort/all")
+    assert response.status_code == 200
+    html = response.data.decode()
+    assert "class=\"stage\"" in html or "class=\"stage\"".replace('"', '&quot;') in html
+    assert html.count("kort-frame") >= 1
+    assert "Kort 1" in html and "Kort 4" in html
+
+
+def test_overlay_kort_not_found(client):
+    response = client.get("/kort/999")
+    assert response.status_code == 404
+    assert "Nieznany kort" in response.get_data(as_text=True)
+
+
+def test_config_page_renders(client):
+    response = client.get("/config")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Konfiguracja Overlay" in html
+    assert "UndefinedError" not in html


### PR DESCRIPTION
## Summary
- add parametrized tests for individual kort views to ensure expected overlays render
- cover the all courts and config pages to verify key HTML elements and serialization
- assert unknown kort requests return 404 responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8aa6cf30832a87cb5fdf3c8e602c