### PR TITLE
Handle missing corner positions in config preview

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -171,7 +171,12 @@
                 {% set label_offset_x = label_config.get('offset_x', 0) %}
                 {% set label_offset_y = label_config.get('offset_y', 0) %}
                 {% set corner_position = (corner_positions|default({})).get(corner, {}) %}
-                <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_position.get('style', '') }} width: {{ (corner_config.view_width | default(0)) * (corner_config.display_scale | default(0)) }}px; height: {{ (corner_config.view_height | default(0)) * (corner_config.display_scale | default(0)) }}px;">
+                {% set safe_scale = (corner_config.display_scale | default(1, true)) | float %}
+                {% set safe_width = (corner_config.view_width | default(690, true)) | float %}
+                {% set safe_height = (corner_config.view_height | default(150, true)) | float %}
+                {% set preview_width = (safe_width * safe_scale) | round(2) %}
+                {% set preview_height = (safe_height * safe_scale) | round(2) %}
+                <div class="preview-card absolute border border-emerald-400/40 rounded-xl bg-emerald-500/10 text-emerald-100/90 overflow-hidden" data-corner="{{ corner }}" style="{{ corner_position.get('style', '') }} width: {{ preview_width }}px; height: {{ preview_height }}px;">
                   <div class="preview-overlay absolute inset-0 bg-gradient-to-br from-emerald-400/10 to-transparent pointer-events-none"></div>
                   <div class="preview-frame absolute bg-gray-500/30 border border-emerald-300/40 rounded-lg" data-preview-frame></div>
                   <span class="preview-label absolute text-[10px] font-semibold uppercase tracking-widest bg-black/70 px-2 py-1 rounded" data-preview-label data-label-position="{{ label_position }}" data-label-offset-x="{{ label_offset_x }}" data-label-offset-y="{{ label_offset_y }}">{{ safe_corner_labels.get(corner, 'Kort') }}</span>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from main import (
     CONFIG_PATH,
     CORNERS,
+    CORNER_LABELS,
     CORNER_POSITION_STYLES,
     app,
     load_config,
@@ -147,3 +148,58 @@ def test_config_template_handles_missing_corner_labels():
     assert "Konfiguracja Overlay" in html
     for corner in CORNERS:
         assert f'data-corner="{corner}"' in html
+
+
+def test_config_template_handles_absent_corner_positions_context():
+    config = load_config()
+
+    with app.app_context():
+        template = app.jinja_env.get_template("config.html")
+        html = template.render(
+            config=config,
+            corners=CORNERS,
+            corner_labels=CORNER_LABELS,
+        )
+
+    assert "Konfiguracja Overlay" in html
+    for corner in CORNERS:
+        assert f'data-corner="{corner}"' in html
+    assert "width:" in html and "height:" in html
+
+
+def test_config_template_handles_missing_corner_position_entries():
+    config = load_config()
+    partial_positions = {"top_left": CORNER_POSITION_STYLES["top_left"]}
+
+    with app.app_context():
+        template = app.jinja_env.get_template("config.html")
+        html = template.render(
+            config=config,
+            corners=CORNERS,
+            corner_labels=CORNER_LABELS,
+            corner_positions=partial_positions,
+        )
+
+    assert "Konfiguracja Overlay" in html
+    for corner in CORNERS:
+        assert f'data-corner="{corner}"' in html
+    assert "width:" in html and "height:" in html
+
+
+def test_config_preview_uses_safe_defaults_for_missing_corner_dimensions():
+    config = load_config()
+    config.setdefault("kort_all", {})["top_left"] = {}
+
+    with app.app_context():
+        template = app.jinja_env.get_template("config.html")
+        html = template.render(
+            config=config,
+            corners=CORNERS,
+            corner_labels=CORNER_LABELS,
+            corner_positions={},
+        )
+
+    assert "Konfiguracja Overlay" in html
+    assert 'data-corner="top_left"' in html
+    assert "width: 690.0px;" in html
+    assert "height: 150.0px;" in html


### PR DESCRIPTION
## Summary
- default preview cards to safe width and height values when corner data is missing
- guard style rendering against absent corner position definitions
- add regression tests covering rendering without corner position data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca8cab4dbc832a9951652a631277dc