### PR TITLE
Use integer kort IDs in routes and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ def index():
     return render_template("index.html", links=OVERLAY_LINKS)
 
 
-@app.route("/kort/<kort_id>")
+@app.route("/kort/<int:kort_id>")
 def overlay_kort(kort_id):
     kort_id = str(kort_id)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,7 +89,8 @@ def test_kort_route_uses_overlay_configuration(client):
     )
     save_config(config)
 
-    response = client.get("/kort/1")
+    kort_id = 1
+    response = client.get(f"/kort/{kort_id}")
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,7 +4,7 @@ from flask import render_template
 from main import app as flask_app
 
 
-@pytest.mark.parametrize("kort_id", ["1", "2"])
+@pytest.mark.parametrize("kort_id", [1, 2])
 def test_overlay_kort_existing(client, kort_id):
     response = client.get(f"/kort/{kort_id}")
     assert response.status_code == 200
@@ -23,10 +23,23 @@ def test_overlay_all_view(client):
     assert "Kort 1" in html and "Kort 4" in html
 
 
+def test_overlay_all_route_registered():
+    rules = [rule.rule for rule in flask_app.url_map.iter_rules("overlay_all")]
+    assert "/kort/all" in rules
+
+
 def test_overlay_kort_not_found(client):
     response = client.get("/kort/999")
     assert response.status_code == 404
     assert "Nieznany kort" in response.get_data(as_text=True)
+
+
+def test_overlay_all_and_non_numeric_kort(client):
+    all_response = client.get("/kort/all")
+    assert all_response.status_code == 200
+
+    non_numeric_response = client.get("/kort/not-a-number")
+    assert non_numeric_response.status_code == 404
 
 
 def test_config_page_renders(client):


### PR DESCRIPTION
## Summary
- enforce integer kort IDs in the /kort route by using Flask's int converter while preserving overlay lookup
- update view tests to exercise numeric kort IDs, verify the /kort/all route registration, and expect 404 for non-numeric IDs
- ensure configuration tests request kort overlays with numeric identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca9df2beb0832aab158acadff46072