### PR TITLE
Handle whitespace and comma separators in float inputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,7 +48,7 @@ def as_int(value, default):
 def as_float(value, default):
     try:
         if isinstance(value, str):
-            value = value.replace(",", ".").strip()
+            value = value.strip().replace(",", ".")
         return float(value)
     except (TypeError, ValueError):
         return default

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,8 +80,8 @@ def test_post_config_updates_overlay_file(client):
 
 def test_post_config_accepts_comma_decimal_values(client):
     payload = {
-        "display_scale": "1,25",
-        "kort_all[top_left][display_scale]": "1,35",
+        "display_scale": " 1,25 ",
+        "kort_all[top_left][display_scale]": " 1,35 ",
     }
 
     response = client.post("/config", data=payload, follow_redirects=True)
@@ -99,6 +99,7 @@ def test_post_config_accepts_comma_decimal_values(client):
 def test_as_float_supports_dot_and_comma_decimal_separators():
     assert as_float("1.25", 0.0) == pytest.approx(1.25)
     assert as_float("1,25", 0.0) == pytest.approx(1.25)
+    assert as_float(" 1,25 ", 0.0) == pytest.approx(1.25)
 
 
 def test_kort_route_uses_overlay_configuration(client):


### PR DESCRIPTION
## Summary
- trim whitespace and normalize comma separators before float parsing
- expand configuration POST test to cover comma decimal inputs and JSON persistence
- document as_float behavior with whitespace-trimmed comma values

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cabd215950832aa0e669d36b8dddb3