### PR TITLE
Normalize decimal separators for float parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,9 +47,11 @@ def as_int(value, default):
 
 def as_float(value, default):
     try:
-        if isinstance(value, str):
-            value = value.strip().replace(",", ".")
-        return float(value)
+        normalized = value
+        if not isinstance(normalized, str):
+            normalized = str(normalized)
+        normalized = normalized.strip().replace(",", ".")
+        return float(normalized)
     except (TypeError, ValueError):
         return default
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,17 @@ def test_post_config_updates_overlay_file(client):
     assert bottom_right["offset_x"] == -12
     assert bottom_right["label"]["position"] == "top-right"
 
+    comma_payload = {
+        "display_scale": "1,25",
+    }
+
+    response = client.post("/config", data=comma_payload, follow_redirects=True)
+
+    assert response.status_code == 200
+
+    written = json.loads(config_path.read_text())
+    assert written["display_scale"] == pytest.approx(1.25)
+
 
 def test_post_config_accepts_comma_decimal_values(client):
     payload = {


### PR DESCRIPTION
## Summary
- normalize decimal separator handling in `as_float` by trimming whitespace and replacing commas before parsing
- extend configuration POST test to cover comma-based decimal inputs and ensure JSON persistence

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cac277fad4832aba90f46924e680f2