### PR TITLE
Normalize comma decimals in config preview

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -257,14 +257,23 @@
         if (typeof normalized === 'number') {
           return Number.isFinite(normalized) ? normalized : fallback;
         }
+        if (typeof normalized === 'string') {
+          const cleaned = normalized.replace(/,/g, '.');
+          const parsed = Number(cleaned);
+          return Number.isFinite(parsed) ? parsed : fallback;
+        }
         const parsed = Number(normalized);
         return Number.isFinite(parsed) ? parsed : fallback;
       }
 
       function parseFieldValue(field) {
         if (field.type === 'number') {
-          const normalized = normalizeNumberInput(field.value);
-          if (normalized === '') {
+          const rawValue = field.value;
+          const normalized =
+            typeof rawValue === 'string'
+              ? rawValue.trim().replace(/,/g, '.')
+              : normalizeNumberInput(rawValue);
+          if (normalized === '' || normalized === null || normalized === undefined) {
             return NaN;
           }
           if (typeof normalized === 'number') {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,6 +141,25 @@ def test_config_preview_uses_comma_decimal_values_in_styles(client):
     assert width_px == pytest.approx(640 * 1.25)
     assert height_px == pytest.approx(200 * 1.25)
 
+    overlay_response = client.get("/kort/all")
+    assert overlay_response.status_code == 200
+
+    overlay_soup = BeautifulSoup(overlay_response.get_data(as_text=True), "html.parser")
+    top_left_container = overlay_soup.select_one('[data-position="top-left"]')
+    assert top_left_container is not None
+
+    container_style = top_left_container.get("style", "")
+    container_width = extract_px_value(container_style, "width")
+    container_height = extract_px_value(container_style, "height")
+
+    assert container_width == pytest.approx(640 * 1.25)
+    assert container_height == pytest.approx(200 * 1.25)
+
+    iframe = top_left_container.select_one("iframe.kort-frame")
+    assert iframe is not None
+    iframe_style = iframe.get("style", "")
+    assert "scale(1.25)" in iframe_style
+
 
 def test_as_float_supports_dot_and_comma_decimal_separators():
     assert as_float("1.25", 0.0) == pytest.approx(1.25)


### PR DESCRIPTION
## Summary
- normalize number inputs in the config preview script so comma decimals are converted before coercion
- extend the comma-decimal preview test to assert iframe widths and scales reflect a 1.25 factor

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cac3ea124c832a83b4ddf21e4991c7