### PR TITLE
Add basic auth protection to config view

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,18 @@
+import base64
+
 import pytest
 
 from main import app, db
+
+
+@pytest.fixture
+def auth_headers(monkeypatch):
+    username = "test-user"
+    password = "test-pass"
+    monkeypatch.setenv("CONFIG_AUTH_USERNAME", username)
+    monkeypatch.setenv("CONFIG_AUTH_PASSWORD", password)
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
 
 
 @pytest.fixture

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -42,8 +42,8 @@ def test_overlay_all_and_non_numeric_kort(client):
     assert non_numeric_response.status_code == 404
 
 
-def test_config_page_renders(client):
-    response = client.get("/config")
+def test_config_page_renders(client, auth_headers):
+    response = client.get("/config", headers=auth_headers)
     assert response.status_code == 200
     html = response.get_data(as_text=True)
     assert "Konfiguracja Overlay" in html


### PR DESCRIPTION
## Summary
- add a reusable decorator that enforces HTTP Basic Auth for the /config view using environment-provided credentials
- expose shared test fixtures for authorization headers and update config-focused tests to authenticate before hitting the protected endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cad40d92d0832a9dcf6008ab7dc0b7