### PR TITLE
Handle missing overlay links page endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import os
 from functools import wraps
 from urllib.parse import urlparse
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, jsonify, render_template, request, url_for
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 
@@ -461,7 +461,15 @@ def render_config(config_dict):
 @app.route("/")
 def index():
     links = overlay_links_by_kort_id()
-    return render_template("index.html", links=links)
+    links_management_url = None
+    if "overlay_links_page" in app.view_functions:
+        links_management_url = url_for("overlay_links_page")
+
+    return render_template(
+        "index.html",
+        links=links,
+        links_management_url=links_management_url,
+    )
 
 
 @app.route("/kort/<int:kort_id>")

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,9 @@
       </div>
       <div class="flex flex-col sm:flex-row gap-3 justify-center">
         <a href="{{ url_for('config') }}" class="inline-block px-6 py-3 bg-gray-700 hover:bg-gray-600 rounded text-white text-lg font-semibold">Ustawienia overlayu</a>
-        <a href="{{ url_for('overlay_links_page') }}" class="inline-block px-6 py-3 bg-blue-700 hover:bg-blue-600 rounded text-white text-lg font-semibold">Zarządzaj linkami</a>
+        {% if links_management_url %}
+        <a href="{{ links_management_url }}" class="inline-block px-6 py-3 bg-blue-700 hover:bg-blue-600 rounded text-white text-lg font-semibold">Zarządzaj linkami</a>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- guard the index view against missing overlay management endpoint
- hide the "Zarządzaj linkami" button when the route is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cad9694c38832abdd5f771ddaacc42