### PR TITLE
Implement command-based polling cycle with alternating players

### DIFF
--- a/results_state_machine.py
+++ b/results_state_machine.py
@@ -6,7 +6,7 @@ import enum
 import hashlib
 import json
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 
 class CourtPhase(enum.Enum):
@@ -57,6 +57,10 @@ class CourtState:
     finished_name_signature: Optional[str] = None
     finished_raw_signature: Optional[str] = None
     phase_offset: float = field(default=None)
+    tick_counter: int = 0
+    command_index: int = 0
+    next_player: str = "A"
+    pending_players: List[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.phase_offset is None:
@@ -76,6 +80,9 @@ class CourtState:
             return
         self.phase = phase
         self.phase_started_at = now
+        self.command_index = 0
+        self.pending_players.clear()
+        self.next_player = "A"
         if phase is not CourtPhase.FINISHED:
             self.finished_name_signature = None
             self.finished_raw_signature = None


### PR DESCRIPTION
## Summary
- introduce a per-phase COMMAND_PLAN and alternating command selection with name stabilization in the polling loop
- extend CourtState with tick counters and player rotation tracking to support the new polling cadence
- merge partial command payloads into snapshots, adjust phase classification, and expand tests to cover command sequencing and phase transitions

## Testing
- pytest tests/test_results.py

------
https://chatgpt.com/codex/tasks/task_e_68dd088a695c832a8ccf891370e0acd6