### PR TITLE
Switch control app polling to PUT requests

### DIFF
--- a/results.py
+++ b/results.py
@@ -666,14 +666,14 @@ def update_snapshot_for_kort(
         return _mark_unavailable(kort_id, error=str(exc))
     http = session or requests
     try:
-        response = http.get(
+        response = http.put(
             output_url,
-            params={"command": FULL_SNAPSHOT_COMMAND},
+            json={"command": FULL_SNAPSHOT_COMMAND},
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
         logger.info(
             "Żądanie %s %s zakończone statusem %s",
-            "GET",
+            "PUT",
             response.url,
             response.status_code,
         )
@@ -790,7 +790,7 @@ def _update_once(
             continue
 
         http = session or requests
-        params = {"command": command}
+        payload = {"command": command}
         attempt = 0
         final_snapshot: Optional[Dict[str, Any]] = None
         last_error: Optional[str] = None
@@ -800,14 +800,14 @@ def _update_once(
             should_retry = False
             try:
                 _throttle_request(controlapp_identifier, current_time=current_time)
-                response = http.get(
+                response = http.put(
                     base_url,
-                    params=params,
+                    json=payload,
                     timeout=REQUEST_TIMEOUT_SECONDS,
                 )
                 logger.debug(
                     "Żądanie %s %s zakończone statusem %s",
-                    "GET",
+                    "PUT",
                     response.url,
                     response.status_code,
                 )


### PR DESCRIPTION
## Summary
- send overlay commands using PUT with JSON payloads in the results updater
- update full snapshot retrieval to log PUT requests when requesting the full snapshot
- adjust test sessions to assert PUT usage and JSON payload handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd75637d08832ab24b3d510686d3ac