### PR TITLE
Pin Python dependencies for Flask app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-flask
-flask-cors
-Flask-SQLAlchemy
-requests
-python-dotenv
+Flask==3.0.3
+flask-cors==4.0.1
+Flask-SQLAlchemy==3.1.1
+requests==2.32.3
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- pin Flask, Flask-SQLAlchemy, flask-cors, requests, and python-dotenv to versions compatible with Python 3.10+
- verify the new requirement pins by reinstalling dependencies

## Testing
- pip install -r requirements.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68deaac1c568832aa5e3eb48ec417e2f