### PR TITLE
Persist overlay database in docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 instance/
+data/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Aplikacja Flask do zarządzania linkami i konfiguracją overlayów wykorzystywan
    ```
    Alternatywnie możesz wystartować aplikację poleceniem `python main.py` lub użyć kontenera Docker (`docker-compose up`).
 
+### Trwałość danych w Docker Compose
+
+Plik bazy danych `overlay.db` jest przechowywany w katalogu `data/`, który jest montowany do kontenera jako wolumen (`./data:/app/data`).
+Pozwala to utrzymać dane między restartami kontenera.
+
+1. Przy pierwszym uruchomieniu wykonaj `docker-compose up`. Katalog `data/` zostanie utworzony automatycznie i zapisze się w nim plik `overlay.db`.
+2. Zatrzymaj kontener (`Ctrl+C` lub `docker-compose down`).
+3. Upewnij się, że plik `data/overlay.db` nadal istnieje na hoście.
+4. Ponownie uruchom usługę (`docker-compose up`) – kontener wczyta istniejącą bazę i zachowa wszystkie dane.
+
+Zmienne `CONFIG_AUTH_USERNAME` oraz `CONFIG_AUTH_PASSWORD` możesz zdefiniować w pliku `.env`, aby `docker-compose` przekazał je do kontenera (wspierane są również wartości ustawione w środowisku systemowym).
+
 Po uruchomieniu aplikacja nasłuchuje na porcie określonym zmienną `PORT` (domyślnie `5000`). Baza danych `overlay.db` zostanie utworzona automatycznie przy pierwszym starcie.
 
 ## Konfiguracja środowiska
@@ -43,7 +55,7 @@ W pliku `.env.example` znajdują się wszystkie najważniejsze zmienne środowis
 | `FLASK_APP` | Nazwa modułu używanego przez `flask run`. |
 | `FLASK_ENV` | Tryb pracy aplikacji (np. `development` lub `production`). |
 | `PORT` | Port, na którym aplikacja nasłuchuje żądań HTTP. |
-| `DATABASE_URL` | URI bazy danych SQLAlchemy. Domyślnie używany jest plik `sqlite:///overlay.db`. |
+| `DATABASE_URL` | URI bazy danych SQLAlchemy. Domyślnie używany jest plik `sqlite:///overlay.db` (dla uruchomień lokalnych); `docker-compose` wskazuje na `sqlite:///data/overlay.db`. |
 | `CONFIG_AUTH_USERNAME` | Login wymagany przy dostępie do panelu `/config`. |
 | `CONFIG_AUTH_PASSWORD` | Hasło do panelu konfiguracji. |
 | `LOG_LEVEL` | Poziom logowania aplikacji (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,13 @@ services:
     ports:
       - "5000:5000"
     volumes:
+      - ./data:/app/data
       - ./templates:/app/templates
       - ./overlay_links.json:/app/overlay_links.json
+    environment:
+      - DATABASE_URL=sqlite:///data/overlay.db
+      - CONFIG_AUTH_USERNAME=${CONFIG_AUTH_USERNAME:-}
+      - CONFIG_AUTH_PASSWORD=${CONFIG_AUTH_PASSWORD:-}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.tenis.rule=Host(`tenis.dawidsuchodolski.pl`)"


### PR DESCRIPTION
## Summary
- mount a host data directory so the overlay SQLite database survives container restarts
- configure docker-compose to expose the database URL and configuration auth credentials to the service
- document the persistent data directory usage and ensure the generated data directory stays out of version control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deab6354c8832abb48eff9c41914f1