### PR TITLE
Normalize status handling and surface overlay telemetry

### DIFF
--- a/templates/kort.html
+++ b/templates/kort.html
@@ -44,12 +44,82 @@
       padding: 3px 8px;
       border-radius: 6px;
     }
+
+    .status-panel {
+      position: absolute;
+      top: 16px;
+      left: 16px;
+      z-index: 20;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-family: sans-serif;
+      color: #f8fafc;
+      text-shadow: 1px 1px 2px black;
+      background: rgba(0, 0, 0, 0.45);
+      padding: 8px 12px;
+      border-radius: 8px;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 700;
+      font-size: 0.9rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      width: fit-content;
+    }
+
+    .status-on {
+      background: rgba(74, 222, 128, 0.18);
+      color: #4ade80;
+      border-color: rgba(74, 222, 128, 0.45);
+    }
+
+    .status-off {
+      background: rgba(239, 68, 68, 0.2);
+      color: #fca5a5;
+      border-color: rgba(239, 68, 68, 0.45);
+    }
+
+    .status-info {
+      font-size: 0.85rem;
+    }
+
+    .mini-meta {
+      margin-top: 4px;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      font-size: 12px;
+    }
+
+    .mini-meta time,
+    .mini-meta span {
+      display: block;
+    }
   </style>
 </head>
 <body>
 
   <!-- Główna nakładka -->
   <iframe class="overlay-main" src="{{ main_overlay }}"></iframe>
+
+  {% set snapshot = main_snapshot | default({}) %}
+  <div class="status-panel" aria-live="polite">
+    <span class="status-pill status-{{ 'on' if snapshot.overlay_is_on else 'off' }}">Overlay: {{ snapshot.overlay_label | default('OFF') }}</span>
+    <span class="status-info">Status: {{ snapshot.status_label | default('Brak danych') }}</span>
+    {% if snapshot.last_updated %}
+    <time class="status-info" datetime="{{ snapshot.last_updated }}">Ostatnia aktualizacja: {{ snapshot.last_updated }}</time>
+    {% else %}
+    <span class="status-info">Ostatnia aktualizacja: brak danych</span>
+    {% endif %}
+  </div>
 
   <!-- Pasek górny z miniaturami -->
   <div class="top-strip">
@@ -92,7 +162,7 @@
     {% set effective_label_style = mini_label_style | default(computed_label_style) %}
 
     {% if mini_config %}
-      {% for i, url in mini_overlays | default([]) %}
+      {% for mini in mini_overlays | default([]) %}
         <div class="mini-overlay"
              style="width: {{ (mini_config.view_width | default(fallback_mini_config.view_width | default(default_mini_config.view_width)))
                                 * (mini_config.display_scale | default(fallback_mini_config.display_scale | default(default_mini_config.display_scale))) }}px;
@@ -106,7 +176,7 @@
 
           <!-- Przesunięty fragment wycinka -->
           <iframe
-            src="{{ url }}"
+            src="{{ mini.overlay }}"
             style="
               width: 1920px;
               height: 1080px;
@@ -120,7 +190,16 @@
 
           <!-- Etykieta kortu -->
           <div class="kort-label" style="{{ effective_label_style }}">
-            Kort {{ i }}
+            <div>Kort {{ mini.kort_id }}</div>
+            <div class="mini-meta">
+              <span class="status-pill status-{{ 'on' if mini.overlay_is_on else 'off' }}" style="font-size: 0.75rem; padding: 0.15rem 0.55rem;">Overlay: {{ mini.overlay_label }}</span>
+              <span>Status: {{ mini.status_label }}</span>
+              {% if mini.last_updated %}
+              <time datetime="{{ mini.last_updated }}">Ostatnia aktualizacja: {{ mini.last_updated }}</time>
+              {% else %}
+              <span>Ostatnia aktualizacja: brak danych</span>
+              {% endif %}
+            </div>
           </div>
 
         </div>

--- a/templates/kort_all.html
+++ b/templates/kort_all.html
@@ -49,6 +49,46 @@
       padding: 4px 10px;
       border-radius: 6px;
     }
+
+    .kort-meta {
+      position: absolute;
+      left: 10px;
+      bottom: 10px;
+      background: rgba(0, 0, 0, 0.55);
+      border-radius: 10px;
+      padding: 8px 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 13px;
+      text-shadow: 1px 1px 2px #000;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 700;
+      font-size: 0.85rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      width: fit-content;
+    }
+
+    .status-on {
+      background: rgba(74, 222, 128, 0.2);
+      color: #4ade80;
+      border-color: rgba(74, 222, 128, 0.45);
+    }
+
+    .status-off {
+      background: rgba(239, 68, 68, 0.2);
+      color: #fca5a5;
+      border-color: rgba(239, 68, 68, 0.45);
+    }
   </style>
 </head>
 <body>
@@ -63,6 +103,15 @@
                 style="transform: scale({{ kort.config.display_scale }}); transform-origin: bottom left; left: {{ kort.config.offset_x }}px; bottom: {{ kort.config.offset_y }}px;"></iframe>
         <div class="kort-label" style="{{ kort.label_style }}">
           Kort {{ kort.id }}
+        </div>
+        <div class="kort-meta" aria-live="polite">
+          <span class="status-pill status-{{ 'on' if kort.overlay_is_on else 'off' }}">Overlay: {{ kort.overlay_label }}</span>
+          <span>Status: {{ kort.status_label }}</span>
+          {% if kort.last_updated %}
+          <time datetime="{{ kort.last_updated }}">Ostatnia aktualizacja: {{ kort.last_updated }}</time>
+          {% else %}
+          <span>Ostatnia aktualizacja: brak danych</span>
+          {% endif %}
         </div>
       </div>
     {% endfor %}

--- a/templates/wyniki.html
+++ b/templates/wyniki.html
@@ -100,6 +100,11 @@
       font-weight: 600;
     }
 
+    .status-brak_danych {
+      color: #94a3b8;
+      font-weight: 600;
+    }
+
     .serving-indicator {
       color: #f97316;
       font-weight: 700;
@@ -128,6 +133,36 @@
       gap: 0.25rem;
     }
 
+    .overlay-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      font-weight: 700;
+      padding: 0.2rem 0.65rem;
+      border-radius: 999px;
+      width: fit-content;
+    }
+
+    .overlay-on {
+      background: rgba(74, 222, 128, 0.18);
+      color: #4ade80;
+      border: 1px solid rgba(74, 222, 128, 0.45);
+    }
+
+    .overlay-off {
+      background: rgba(239, 68, 68, 0.2);
+      color: #fca5a5;
+      border: 1px solid rgba(239, 68, 68, 0.45);
+    }
+
+    .last-updated {
+      font-size: 0.85rem;
+      color: #cbd5f5;
+    }
+
     @media (max-width: 768px) {
       main {
         padding: 1.5rem 0.5rem 3rem;
@@ -148,16 +183,17 @@
     <div class="results-container" aria-live="polite">
       <h1>Wyniki meczów tenisowych</h1>
 
-      <section aria-labelledby="active-matches">
-        <h2 id="active-matches">Aktywne mecze</h2>
-        {% if not has_running_matches and active_matches %}
+      {% for section in sections %}
+      <section aria-labelledby="section-{{ section.status }}">
+        <h2 id="section-{{ section.status }}">{{ section.title }}</h2>
+        {% if section.status == 'active' and not has_running_matches and has_non_running_snapshots %}
         <p class="notice">Brak potwierdzonych aktywnych spotkań – prezentujemy ostatnio dostępne korty wraz z informacją o braku danych.</p>
-        {% elif not active_matches %}
-        <p class="notice">Brak aktywnych kortów do wyświetlenia.</p>
+        {% elif not section.matches %}
+        <p class="notice">{{ section.empty_message }}</p>
         {% endif %}
         <div class="table-wrapper">
           <table>
-            <caption>Aktualne spotkania i status kortów</caption>
+            <caption>{{ section.caption }}</caption>
             <thead>
               <tr>
                 <th scope="col">Kort</th>
@@ -169,8 +205,8 @@
               </tr>
             </thead>
             <tbody>
-              {% if active_matches %}
-              {% for match in active_matches %}
+              {% if section.matches %}
+              {% for match in section.matches %}
               {% for player in match.players %}
               <tr>
                 {% if loop.first %}
@@ -186,6 +222,13 @@
                 <td rowspan="{{ match.row_span }}" class="status-{{ match.status }}">{{ match.status_label }}</td>
                 <td rowspan="{{ match.row_span }}">
                   <div class="summary">
+                    <span class="overlay-pill overlay-{{ 'on' if match.overlay_is_on else 'off' }}">Overlay: {{ match.overlay_label }}</span>
+                    {% if match.last_updated %}
+                    <time class="last-updated" datetime="{{ match.last_updated }}">Ostatnia aktualizacja: {{ match.last_updated }}</time>
+                    {% else %}
+                    <span class="last-updated">Ostatnia aktualizacja: brak danych</span>
+                    {% endif %}
+                    <span>Status: {{ match.status_label }}</span>
                     <span>Sety ogółem: {{ match.set_summary }}</span>
                     <span>Stan punktów: {{ match.score_summary }}</span>
                   </div>
@@ -196,64 +239,14 @@
               {% endfor %}
               {% else %}
               <tr>
-                <td class="empty-state" colspan="6">Aktualnie brak danych o aktywnych kortach.</td>
+                <td class="empty-state" colspan="6">{{ section.empty_message }}</td>
               </tr>
               {% endif %}
             </tbody>
           </table>
         </div>
       </section>
-
-      <section aria-labelledby="finished-matches">
-        <h2 id="finished-matches">Zakończone mecze</h2>
-        <div class="table-wrapper">
-          <table>
-            <caption>Zakończone spotkania</caption>
-            <thead>
-              <tr>
-                <th scope="col">Kort</th>
-                <th scope="col">Zawodnik</th>
-                <th scope="col">Sety</th>
-                <th scope="col">Gemy/Punkty</th>
-                <th scope="col">Status</th>
-                <th scope="col">Podsumowanie</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% if finished_matches %}
-              {% for match in finished_matches %}
-              {% for player in match.players %}
-              <tr>
-                {% if loop.first %}
-                <th scope="rowgroup" rowspan="{{ match.row_span }}">{{ match.kort_label }}</th>
-                {% endif %}
-                <th scope="row">
-                  {% if player.is_serving %}<span class="serving-indicator" aria-label="Serwuje">▶</span>{% endif %}
-                  {{ player.display_name }}
-                </th>
-                <td>{{ player.display_sets }}</td>
-                <td>{{ player.display_games }}</td>
-                {% if loop.first %}
-                <td rowspan="{{ match.row_span }}" class="status-{{ match.status }}">{{ match.status_label }}</td>
-                <td rowspan="{{ match.row_span }}">
-                  <div class="summary">
-                    <span>Sety ogółem: {{ match.set_summary }}</span>
-                    <span>Stan punktów: {{ match.score_summary }}</span>
-                  </div>
-                </td>
-                {% endif %}
-              </tr>
-              {% endfor %}
-              {% endfor %}
-              {% else %}
-              <tr>
-                <td class="empty-state" colspan="6">Brak zakończonych meczów do wyświetlenia.</td>
-              </tr>
-              {% endif %}
-            </tbody>
-          </table>
-        </div>
-      </section>
+      {% endfor %}
     </div>
   </main>
 </body>

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -75,10 +75,12 @@ def test_results_page_renders_data(client, snapshots_dir):
 
     assert response.status_code == 200
     assert "<table" in html
-    assert 'aria-live="polite"' in html
+    assert "section-active" in html
     assert "Kort Centralny" in html
     assert "▶" in html
-    assert "brak danych" in html.lower()
+    assert "Overlay: ON" in html
+    assert "Ostatnia aktualizacja:" in html
+    assert "Status: W trakcie" in html
 
 
 def test_results_page_shows_placeholder_for_finished_section(client, snapshots_dir):
@@ -88,6 +90,30 @@ def test_results_page_shows_placeholder_for_finished_section(client, snapshots_d
     assert response.status_code == 200
     assert "Brak zakończonych meczów do wyświetlenia." in html
     assert "Aktualne spotkania i status kortów" in html
+
+
+def test_results_page_marks_unavailable_with_notice(client, snapshots_dir):
+    sample_data = [
+        {
+            "kort_id": "3",
+            "kort": "Kort 3",
+            "status": "active",
+            "available": False,
+            "players": [
+                {"name": "E. Kowal", "sets": 0, "games": 0},
+                {"name": "F. Maj", "sets": 0, "games": 0},
+            ],
+        }
+    ]
+    (snapshots_dir / "latest.json").write_text(json.dumps(sample_data), encoding="utf-8")
+
+    response = client.get("/wyniki")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "Brak potwierdzonych aktywnych spotkań" in html
+    assert "Overlay: OFF" in html
+    assert "Status: Niedostępny" in html
 
 
 # --- Pomocnicze klasy do testów parsera --------------------------------------

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -24,6 +24,8 @@ def test_overlay_all_view(client):
     assert "class=\"stage\"" in html or "class=\"stage\"".replace('"', '&quot;') in html
     assert html.count("kort-frame") >= 1
     assert "Kort 1" in html and "Kort 4" in html
+    assert "Overlay:" in html
+    assert "Ostatnia aktualizacja" in html
 
 
 def test_overlay_all_route_registered():
@@ -155,6 +157,7 @@ def test_overlay_kort_uses_new_link(client):
     assert response.status_code == 200
     html = response.get_data(as_text=True)
     assert new_link["overlay"] in html
+    assert "Overlay:" in html
 
 
 def test_overlay_links_page_renders(client):


### PR DESCRIPTION
## Summary
- normalize snapshot statuses into active, finished, unavailable or brak_danych and attach last-updated metadata
- surface overlay on/off indicators and ISO timestamps across wyniki, kort and kort_all templates using the normalized data
- extend results and view tests to cover the new rendering and availability notice logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dee7cf5180832a94a85bcc39f8b281