### PR TITLE
Limit archived snapshots to recent entries

### DIFF
--- a/results.py
+++ b/results.py
@@ -43,6 +43,8 @@ RETRY_JITTER_MAX_SECONDS = 0.3
 
 FULL_SNAPSHOT_COMMAND = None
 
+ARCHIVE_LIMIT = 50
+
 
 CommandPlanEntry = Dict[str, Any]
 
@@ -883,6 +885,8 @@ def _archive_snapshot(kort_id: str, snapshot: Dict[str, Any]) -> Dict[str, Any]:
     with snapshots_lock:
         history = entry.setdefault("archive", [])
         history.append(archive_entry)
+        if len(history) > ARCHIVE_LIMIT:
+            del history[:-ARCHIVE_LIMIT]
         entry["archive"] = history
         snapshots[str(kort_id)] = entry
     return archive_entry

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -372,6 +372,29 @@ def test_partial_updates_allow_state_progression():
     assert snapshot["last_updated"] is not None
 
 
+def test_archive_snapshot_capped_to_limit():
+    kort_id = "archive-limit"
+
+    for index in range(results_module.ARCHIVE_LIMIT + 10):
+        snapshot = {
+            "kort_id": kort_id,
+            "status": SNAPSHOT_STATUS_OK,
+            "last_updated": str(index),
+            "players": {},
+            "raw": {},
+            "serving": None,
+            "error": None,
+        }
+        results_module._archive_snapshot(kort_id, snapshot)
+
+    archive = results_module.snapshots[kort_id]["archive"]
+    assert len(archive) == results_module.ARCHIVE_LIMIT
+    assert [entry["last_updated"] for entry in archive] == [
+        str(index)
+        for index in range(10, results_module.ARCHIVE_LIMIT + 10)
+    ]
+
+
 def test_update_once_cycles_commands_and_transitions(monkeypatch):
     snapshots.clear()
     results_module.court_states.clear()


### PR DESCRIPTION
## Summary
- add a reusable ARCHIVE_LIMIT constant and trim archive history to the newest entries
- cover the capped archive behavior with a unit test to ensure ordering and length are preserved

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68def008c57c832ab52cff70a10afc59