### PR TITLE
Validate overlay configuration inputs

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -56,6 +56,18 @@
         <p class="text-sm text-gray-300">Dostosuj parametry widoków pojedynczych i wszystkich kortów. Zmiany zapisują się w pliku konfiguracyjnym.</p>
       </header>
 
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          <div class="space-y-2">
+            {% for category, message in messages %}
+              <div class="px-4 py-3 rounded-lg border text-sm {% if category == 'error' %}border-red-500/40 bg-red-500/10 text-red-200{% elif category == 'success' %}border-emerald-500/40 bg-emerald-500/10 text-emerald-100{% else %}border-gray-500/40 bg-gray-700/20 text-gray-100{% endif %}">
+                {{ message }}
+              </div>
+            {% endfor %}
+          </div>
+        {% endif %}
+      {% endwith %}
+
       <section class="space-y-4">
         <h2 class="text-xl font-semibold flex items-center gap-2">🧭 Ustawienia ogólne</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def auth_headers(monkeypatch):
 
 @pytest.fixture
 def client():
-    app.config.update(TESTING=True)
+    app.config.update(TESTING=True, SECRET_KEY="test-secret-key")
     with app.test_client() as client:
         yield client
 


### PR DESCRIPTION
## Summary
- add explicit range and label validation to the configuration view and respond with JSON when requested
- show flashed validation errors in the configuration form when invalid values are submitted
- extend configuration tests to cover invalid submissions, JSON error handling, and real-time UI updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68def2cd7414832aaf1fc766c36cb24a