### PR TITLE
Localize last updated timestamps

### DIFF
--- a/templates/kort.html
+++ b/templates/kort.html
@@ -167,7 +167,7 @@
     <span class="pause-indicator">{{ snapshot.pause_label }}</span>
     {% endif %}
     {% if snapshot.last_updated %}
-    <time class="status-info" datetime="{{ snapshot.last_updated }}">Ostatnia aktualizacja: {{ snapshot.last_updated }}</time>
+    <time class="status-info"{% if snapshot.last_updated_iso %} datetime="{{ snapshot.last_updated_iso }}" title="{{ snapshot.last_updated_iso }}"{% endif %}>Ostatnia aktualizacja: {{ snapshot.last_updated }}</time>
     {% else %}
     <span class="status-info">Ostatnia aktualizacja: brak danych</span>
     {% endif %}
@@ -250,7 +250,7 @@
               <span class="pause-indicator" style="font-size: 0.7rem; padding: 0.2rem 0.5rem;">{{ mini.pause_label }}</span>
               {% endif %}
               {% if mini.last_updated %}
-              <time datetime="{{ mini.last_updated }}">Ostatnia aktualizacja: {{ mini.last_updated }}</time>
+              <time{% if mini.last_updated_iso %} datetime="{{ mini.last_updated_iso }}" title="{{ mini.last_updated_iso }}"{% endif %}>Ostatnia aktualizacja: {{ mini.last_updated }}</time>
               {% else %}
               <span>Ostatnia aktualizacja: brak danych</span>
               {% endif %}

--- a/templates/kort_all.html
+++ b/templates/kort_all.html
@@ -126,7 +126,7 @@
           <span class="pause-indicator">{{ kort.pause_label }}</span>
           {% endif %}
           {% if kort.last_updated %}
-          <time datetime="{{ kort.last_updated }}">Ostatnia aktualizacja: {{ kort.last_updated }}</time>
+          <time{% if kort.last_updated_iso %} datetime="{{ kort.last_updated_iso }}" title="{{ kort.last_updated_iso }}"{% endif %}>Ostatnia aktualizacja: {{ kort.last_updated }}</time>
           {% else %}
           <span>Ostatnia aktualizacja: brak danych</span>
           {% endif %}

--- a/templates/wyniki.html
+++ b/templates/wyniki.html
@@ -275,11 +275,11 @@
                     {% if match.pause_active %}
                     <span class="pause-indicator">{{ match.pause_label }}</span>
                     {% endif %}
-                    {% if match.last_updated %}
-                    <time class="last-updated" datetime="{{ match.last_updated }}">Ostatnia aktualizacja: {{ match.last_updated }}</time>
-                    {% else %}
-                    <span class="last-updated">Ostatnia aktualizacja: brak danych</span>
-                    {% endif %}
+                      {% if match.last_updated %}
+                      <time class="last-updated"{% if match.last_updated_iso %} datetime="{{ match.last_updated_iso }}" title="{{ match.last_updated_iso }}"{% endif %}>Ostatnia aktualizacja: {{ match.last_updated }}</time>
+                      {% else %}
+                      <span class="last-updated">Ostatnia aktualizacja: brak danych</span>
+                      {% endif %}
                     <span>Status: {{ match.status_label }}</span>
                     <span>Sety ogółem: {{ match.set_summary }}</span>
                     <span>Stan punktów: {{ match.score_summary }}</span>


### PR DESCRIPTION
## Summary
- convert snapshot timestamps to Europe/Warsaw for display while retaining UTC ISO metadata
- update court and results templates to show localized text with UTC ISO tooltips
- add a view test that verifies the localized formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e03ae5519c832aab10cb0ed123af36