### PR TITLE
Add control panel test endpoint for courts

### DIFF
--- a/templates/kort.html
+++ b/templates/kort.html
@@ -145,7 +145,103 @@
     .mini-meta span {
       display: block;
     }
+
+    .control-test {
+      margin-top: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .control-test-button {
+      appearance: none;
+      border: 1px solid rgba(148, 163, 184, 0.5);
+      background: rgba(30, 41, 59, 0.7);
+      color: #e2e8f0;
+      font-family: inherit;
+      font-size: 0.85rem;
+      font-weight: 600;
+      padding: 0.45rem 0.75rem;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+
+    .control-test-button:hover,
+    .control-test-button:focus {
+      background: rgba(30, 64, 175, 0.75);
+      border-color: rgba(148, 163, 184, 0.8);
+      outline: none;
+    }
+
+    .control-test-button:disabled,
+    .control-test-button.htmx-request {
+      opacity: 0.65;
+      cursor: progress;
+    }
+
+    .control-test-result {
+      font-size: 0.8rem;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .control-test-result-fragment {
+      border-radius: 6px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.55);
+      padding: 6px 8px;
+      line-height: 1.35;
+    }
+
+    .control-test-result-fragment--ok {
+      border-color: rgba(74, 222, 128, 0.45);
+    }
+
+    .control-test-result-fragment--remote_error,
+    .control-test-result-fragment--error {
+      border-color: rgba(239, 68, 68, 0.45);
+    }
+
+    .control-test-line {
+      margin: 0;
+    }
+
+    .control-test-line--error {
+      color: #fca5a5;
+    }
+
+    .control-test-line--muted {
+      color: #cbd5f5;
+    }
+
+    .control-test-payload {
+      margin: 0;
+      padding: 6px;
+      background: rgba(30, 41, 59, 0.8);
+      border-radius: 4px;
+      white-space: pre-wrap;
+      font-family: 'Fira Code', 'Source Code Pro', monospace;
+      font-size: 0.78rem;
+      color: #e2e8f0;
+      max-height: 160px;
+      overflow-y: auto;
+    }
+
+    .htmx-indicator {
+      display: none;
+      font-size: 0.75rem;
+      color: #cbd5f5;
+    }
+
+    .htmx-request .htmx-indicator,
+    .control-test-button.htmx-request + .htmx-indicator,
+    .htmx-request .control-test-result {
+      display: inline-block;
+    }
   </style>
+  <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
 </head>
 <body>
 
@@ -170,6 +266,20 @@
     <time class="status-info"{% if snapshot.last_updated_iso %} datetime="{{ snapshot.last_updated_iso }}" title="{{ snapshot.last_updated_iso }}"{% endif %}>Ostatnia aktualizacja: {{ snapshot.last_updated }}</time>
     {% else %}
     <span class="status-info">Ostatnia aktualizacja: brak danych</span>
+    {% endif %}
+    {% if kort_id is defined and kort_id %}
+    <div class="control-test">
+      <button
+        type="button"
+        class="control-test-button"
+        hx-post="{{ url_for('kort_control_test', kort_id=kort_id) }}"
+        hx-target="#control-test-result"
+        hx-swap="innerHTML"
+        hx-indicator="#control-test-indicator"
+      >Sprawdź panel sterowania</button>
+      <span id="control-test-indicator" class="htmx-indicator">Ładowanie…</span>
+      <div id="control-test-result" class="control-test-result" aria-live="polite"></div>
+    </div>
     {% endif %}
   </div>
 

--- a/templates/partials/control_test_result.html
+++ b/templates/partials/control_test_result.html
@@ -1,0 +1,19 @@
+<div class="control-test-result-fragment control-test-result-fragment--{{ result.status }}">
+  <p class="control-test-line"><strong>Komenda:</strong> {{ result.command }}</p>
+  <p class="control-test-line"><strong>HTTP status:</strong> {{ result.remote_status if result.remote_status is not none else 'brak' }}</p>
+  <p class="control-test-line"><strong>Czas odpowiedzi:</strong>
+    {% if result.response_time_ms is not none %}
+      {{ '%.2f'|format(result.response_time_ms) }} ms
+    {% else %}
+      brak danych
+    {% endif %}
+  </p>
+  {% if result.error %}
+  <p class="control-test-line control-test-line--error">Błąd: {{ result.error }}</p>
+  {% endif %}
+  {% if result.payload_excerpt %}
+  <pre class="control-test-payload">{{ result.payload_excerpt }}</pre>
+  {% else %}
+  <p class="control-test-line control-test-line--muted">Brak danych w odpowiedzi.</p>
+  {% endif %}
+</div>


### PR DESCRIPTION
## Summary
- add a `/kort/<id>/test` endpoint that sends a safe GetStatus control command and renders a diagnostic response snippet
- enhance the single court view with an HTMX button and styles that trigger the new endpoint and show the result inline
- cover the control test flow with view tests simulating button usage and handling both success and timeout scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e03dbab22c832aa1e404ca1670ab74