### PR TITLE
Support hidden and disabled overlay links

### DIFF
--- a/overlay_links.json
+++ b/overlay_links.json
@@ -1,18 +1,26 @@
 {
   "1": {
     "overlay": "https://app.overlays.uno/output/1saktr9IPjVvlEIEVU2Gdw",
-    "control": "https://app.overlays.uno/control/39JHXorTc0vMpAlW6XN8Ro"
+    "control": "https://app.overlays.uno/control/39JHXorTc0vMpAlW6XN8Ro",
+    "enabled": true,
+    "hidden": false
   },
   "2": {
     "overlay": "https://app.overlays.uno/output/25nx4poWfHpME6Z06TSsPB",
-    "control": "https://app.overlays.uno/control/08m9Sn1wThSal2knEKahcP"
+    "control": "https://app.overlays.uno/control/08m9Sn1wThSal2knEKahcP",
+    "enabled": true,
+    "hidden": false
   },
   "3": {
     "overlay": "https://app.overlays.uno/output/5djH9rEb3uYjW6h7AkaP0y",
-    "control": "https://app.overlays.uno/control/1axPce2Jb5vMcoJVmzgSWj"
+    "control": "https://app.overlays.uno/control/1axPce2Jb5vMcoJVmzgSWj",
+    "enabled": true,
+    "hidden": false
   },
   "4": {
     "overlay": "https://app.overlays.uno/output/7yweWqZAiw4y7RU1gMx956",
-    "control": "https://app.overlays.uno/control/3NCqqR3O1IV7jW9ZJu2ioh"
+    "control": "https://app.overlays.uno/control/3NCqqR3O1IV7jW9ZJu2ioh",
+    "enabled": true,
+    "hidden": false
   }
 }

--- a/results.py
+++ b/results.py
@@ -1198,7 +1198,7 @@ def _mark_unavailable(kort_id: str, *, error: Optional[str]) -> Dict[str, Any]:
 
 def _update_once(
     app,
-    overlay_links_supplier: Callable[[], Dict[str, Dict[str, str]]],
+    overlay_links_supplier: Callable[[], Dict[str, Dict[str, Any]]],
     *,
     session: Optional[requests.sessions.Session] = None,
     now: Optional[float] = None,
@@ -1212,6 +1212,10 @@ def _update_once(
         return
 
     for kort_id, urls in links.items():
+        if not (urls or {}).get("enabled", True):
+            logger.debug("Pominięto kort %s - polling wyłączony", kort_id)
+            continue
+
         ensure_snapshot_entry(kort_id)
         state = _ensure_court_state(kort_id)
         control_url = (urls or {}).get("control")

--- a/templates/wyniki.html
+++ b/templates/wyniki.html
@@ -100,6 +100,11 @@
       font-weight: 600;
     }
 
+    .status-disabled {
+      color: #fca5a5;
+      font-weight: 600;
+    }
+
     .status-brak_danych {
       color: #94a3b8;
       font-weight: 600;


### PR DESCRIPTION
## Summary
- add `enabled` and `hidden` flags to overlay links, including database schema validation, JSON seeding, and API support
- treat disabled courts as a dedicated status while filtering hidden courts from rendered views and overlays
- extend normalization and background polling to respect the new flags and cover the behaviour with refreshed tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e040538b78832ab7f59713a6681699