### PR TITLE
Use in-memory snapshots for wyniki views

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,7 @@ import requests
 from results import (
     build_output_url,
     get_metrics_snapshot,
+    get_all_snapshots,
     snapshots,
     start_background_updater,
 )
@@ -1277,8 +1278,15 @@ def index():
     )
 
 
+def _get_snapshots_with_fallback() -> dict[str, dict[str, object]]:
+    current = get_all_snapshots()
+    if current:
+        return current
+    return load_snapshots()
+
+
 def build_wyniki_context():
-    snapshots = load_snapshots()
+    snapshots = _get_snapshots_with_fallback()
     links = overlay_links_by_kort_id()
 
     hidden_ids = {str(kort_id) for kort_id, meta in links.items() if (meta or {}).get("hidden")}
@@ -1379,7 +1387,7 @@ def overlay_kort(kort_id):
     mini_config = kort_all_config.get("top_left") or get_default_corner_config("top_left")
     mini_label_style = build_label_style(mini_config.get("label"))
 
-    snapshots = load_snapshots()
+    snapshots = _get_snapshots_with_fallback()
     main_overlay = links_by_id[kort_id]["overlay"]
     main_snapshot = normalize_snapshot_entry(
         kort_id,
@@ -1522,7 +1530,7 @@ def overlay_all():
 
     overlays = []
     sorted_overlays = [link.to_dict() for link in get_overlay_links() if not link.hidden]
-    snapshots = load_snapshots()
+    snapshots = _get_snapshots_with_fallback()
 
     for link, corner_key in zip(sorted_overlays, CORNERS):
         kort_id = link["kort_id"]

--- a/results.py
+++ b/results.py
@@ -162,6 +162,13 @@ states_lock = threading.Lock()
 metrics_lock = threading.Lock()
 
 
+def get_all_snapshots() -> Dict[str, Dict[str, Any]]:
+    """Return a deep copy of all current snapshots under a thread lock."""
+
+    with snapshots_lock:
+        return copy.deepcopy(snapshots)
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -1605,6 +1612,7 @@ __all__ = [
     "SNAPSHOT_STATUS_UNAVAILABLE",
     "build_output_url",
     "ensure_snapshot_entry",
+    "get_all_snapshots",
     "get_metrics_snapshot",
     "parse_overlay_json",
     "reset_metrics",

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -47,7 +47,7 @@ def setup_function(function):
 
 # --- Testy widoku /wyniki -----------------------------------------------------
 
-def test_results_page_renders_data(client, snapshots_dir):
+def test_results_page_renders_data(client, snapshot_injector):
     sample_data = [
         {
             "kort_id": "1",
@@ -74,7 +74,8 @@ def test_results_page_renders_data(client, snapshots_dir):
             "game_score": "6-3, 6-3",
         },
     ]
-    (snapshots_dir / "latest.json").write_text(json.dumps(sample_data), encoding="utf-8")
+
+    snapshot_injector({entry["kort_id"]: entry for entry in sample_data})
 
     response = client.get("/wyniki")
     html = response.get_data(as_text=True)
@@ -98,7 +99,7 @@ def test_results_page_shows_placeholder_for_finished_section(client, snapshots_d
     assert "Aktualne spotkania i status kortów" in html
 
 
-def test_results_page_marks_unavailable_with_notice(client, snapshots_dir):
+def test_results_page_marks_unavailable_with_notice(client, snapshot_injector):
     sample_data = [
         {
             "kort_id": "3",
@@ -111,7 +112,8 @@ def test_results_page_marks_unavailable_with_notice(client, snapshots_dir):
             ],
         }
     ]
-    (snapshots_dir / "latest.json").write_text(json.dumps(sample_data), encoding="utf-8")
+
+    snapshot_injector({entry["kort_id"]: entry for entry in sample_data})
 
     response = client.get("/wyniki")
     html = response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- add a helper that returns a locked copy of in-memory snapshots
- update wyniki-related views to prefer in-memory snapshots with file fallback
- adjust tests to inject snapshots directly instead of writing temporary files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0585f2848832ab9b45f585d769ca3