### PR TITLE
Adjust throttle simulation handling and add cooldown test

### DIFF
--- a/results.py
+++ b/results.py
@@ -349,8 +349,18 @@ def _sleep(duration: float) -> None:
     time.sleep(duration)
 
 
-def _throttle_request(controlapp_id: str, *, current_time: Optional[float] = None) -> None:
-    simulated_time = current_time
+def _throttle_request(
+    controlapp_id: str,
+    *,
+    simulate: bool = False,
+    current_time: Optional[float] = None,
+) -> None:
+    if simulate:
+        if current_time is None:
+            raise ValueError("current_time is required when simulate=True")
+        simulated_time = current_time
+    else:
+        simulated_time = None
     while True:
         with _throttle_lock:
             now_value = simulated_time if simulated_time is not None else time.time()
@@ -1295,7 +1305,7 @@ def _update_once(
             status_code: Optional[int] = None
             try:
                 try:
-                    _throttle_request(controlapp_identifier, current_time=current_time)
+                    _throttle_request(controlapp_identifier)
                     response = http.put(
                         base_url,
                         json=payload,


### PR DESCRIPTION
## Summary
- make the throttle helper opt-in for simulated time and keep production calls using real time
- update the command polling loop to use the new throttle signature and ensure tests can simulate timings
- add a regression test covering cooldown handling after HTTP 429 responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0572cd844832a81071dcb2b0cd2df