### PR TITLE
Handle wait-reset polling pauses and surface overlay badge

### DIFF
--- a/results_state_machine.py
+++ b/results_state_machine.py
@@ -27,6 +27,7 @@ class CourtPollingStage(enum.Enum):
 
     NORMAL = "normal"
     OFF = "off"
+    OFF_UNTIL_RESET = "off_until_reset"
 
 
 def _default_offset(kort_id: str) -> float:
@@ -194,6 +195,7 @@ _COMMAND_SPECS: Dict[
 ] = {
     CourtPollingStage.NORMAL: _NORMAL_COMMAND_SPECS,
     CourtPollingStage.OFF: _OFF_STAGE_COMMAND_SPECS,
+    CourtPollingStage.OFF_UNTIL_RESET: {},
 }
 
 
@@ -271,6 +273,9 @@ class CourtState:
             return
         self.stage = stage
         self.stage_started_at = now
+        if stage is CourtPollingStage.NORMAL:
+            self.pending_players_by_spec.clear()
+            self.next_player_by_spec.clear()
         self._configure_phase_commands(now)
 
     def compute_name_signature(self, snapshot: Dict[str, object]) -> str:


### PR DESCRIPTION
## Summary
- add an OFF_UNTIL_RESET polling stage and reset pending command queues when returning to normal
- track wait-reset metadata in snapshots and pause scheduling until the reset timestamp when daily limits are exhausted
- expose the WAIT-RESET overlay label/badge in the UI and extend coverage for the new stage

## Testing
- pytest tests/test_results.py
- pytest tests/test_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e253aac5f8832a960e2483d5a1e1a5