### PR TITLE
Add partial status for name-only scoreboard data

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,11 +157,12 @@ STATUS_LABELS = {
     "disabled": "Wyłączony",
     "unavailable": "Niedostępny",
     "brak_danych": "Brak danych",
+    "partial": "Niepełne dane",
 }
 
 UNAVAILABLE_STATUSES = {"unavailable", "niedostępny", "niedostepny"}
 NO_DATA_STATUSES = {"brak danych", "brak_danych", "no data", "no_data"}
-STATUS_ORDER = ["active", "finished", "disabled", "unavailable", "brak_danych"]
+STATUS_ORDER = ["active", "finished", "disabled", "unavailable", "partial", "brak_danych"]
 STATUS_VIEW_META = {
     "active": {
         "title": "Aktywne mecze",
@@ -182,6 +183,11 @@ STATUS_VIEW_META = {
         "title": "Korty niedostępne",
         "caption": "Ostatnio obserwowane korty bez dostępu",
         "empty_message": "Wszystkie korty są obecnie dostępne.",
+    },
+    "partial": {
+        "title": "Korty z niepełnymi danymi",
+        "caption": "Korty z częściowymi aktualizacjami (np. tylko nazwiska)",
+        "empty_message": "Brak kortów z niepełnymi danymi.",
     },
     "brak_danych": {
         "title": "Korty bez danych",
@@ -588,7 +594,9 @@ def normalize_status(raw_status, available, has_snapshot):
     if status_text in NO_DATA_STATUSES:
         return "brak_danych"
 
-    if status_text in FINISHED_STATUSES:
+    if status_text == "partial":
+        base_status = "partial"
+    elif status_text in FINISHED_STATUSES:
         base_status = "finished"
     elif status_text in ACTIVE_STATUSES or status_text == "ok":
         base_status = "active"
@@ -597,7 +605,7 @@ def normalize_status(raw_status, available, has_snapshot):
     else:
         base_status = "active"
 
-    if not available and base_status != "brak_danych":
+    if not available and base_status not in {"brak_danych", "partial"}:
         return "unavailable"
 
     return base_status

--- a/templates/wyniki.html
+++ b/templates/wyniki.html
@@ -105,6 +105,11 @@
       font-weight: 600;
     }
 
+    .status-partial {
+      color: #60a5fa;
+      font-weight: 600;
+    }
+
     .status-brak_danych {
       color: #94a3b8;
       font-weight: 600;

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -75,6 +75,22 @@ def test_wyniki_view_localizes_last_updated(client, monkeypatch, snapshot_inject
     assert 'title="2024-07-01T14:32:00Z"' in html
 
 
+def test_normalize_snapshot_entry_partial_status_label():
+    snapshot = {
+        "status": results.SNAPSHOT_STATUS_PARTIAL,
+        "available": True,
+        "players": [
+            {"name": "A. Kowalski"},
+            {"name": "B. Zielińska"},
+        ],
+    }
+
+    normalized = main.normalize_snapshot_entry("1", snapshot, {})
+
+    assert normalized["status"] == "partial"
+    assert normalized["status_label"] == main.STATUS_LABELS["partial"]
+
+
 def test_wyniki_hides_hidden_and_marks_disabled(client):
     with flask_app.app_context():
         main.ensure_overlay_links_seeded()


### PR DESCRIPTION
## Summary
- mark merged snapshots as `partial` when only player names are known without the full score
- expose the new partial status in the results UI with translated labels and styling
- extend unit tests to cover partial snapshots and status normalization

## Testing
- pytest tests/test_results.py -k partial -vv
- pytest tests/test_config.py -q
- pytest tests/test_views.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e268f19024832a865990fd85593920