### PR TITLE
Prevent blank name updates from overwriting player names

### DIFF
--- a/results.py
+++ b/results.py
@@ -1044,7 +1044,15 @@ def _merge_partial_payload(kort_id: str, partial: Dict[str, Any]) -> Dict[str, A
             player_entry = merged_players.setdefault(suffix, {})
             name = info.get("name")
             if name is not None:
-                player_entry["name"] = name
+                if isinstance(name, str):
+                    if name.strip():
+                        player_entry["name"] = name
+                    else:
+                        existing_name = player_entry.get("name")
+                        if not (isinstance(existing_name, str) and existing_name.strip()):
+                            player_entry["name"] = name
+                else:
+                    player_entry["name"] = name
             points = info.get("points")
             if points is not None:
                 player_entry["points"] = points

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -368,6 +368,20 @@ def test_merge_partial_payload_name_only_updates_set_partial_status():
     assert snapshot["status"] == SNAPSHOT_STATUS_PARTIAL
 
 
+def test_merge_partial_payload_preserves_existing_name_on_blank_update():
+    kort_id = "blank-name"
+
+    initial = results_module._flatten_overlay_payload({"NamePlayerA": "A. Kowalski"})
+    snapshot = results_module._merge_partial_payload(kort_id, initial)
+
+    assert snapshot["players"]["A"]["name"] == "A. Kowalski"
+
+    blank = results_module._flatten_overlay_payload({"NamePlayerA": "   "})
+    snapshot = results_module._merge_partial_payload(kort_id, blank)
+
+    assert snapshot["players"]["A"]["name"] == "A. Kowalski"
+
+
 def test_partial_updates_allow_state_progression():
     kort_id = "2"
     state = results_module._ensure_court_state(kort_id)


### PR DESCRIPTION
## Summary
- avoid replacing stored player names with blank or whitespace-only updates during partial payload merges
- add a regression test covering blank name payloads following a valid name update

## Testing
- pytest tests/test_results.py -k "blank_name or preserves_existing_name_on_blank_update" -q

------
https://chatgpt.com/codex/tasks/task_e_68e26c302964832a94fd534546ea4e16