### PR TITLE
Handle 429s without incrementing command error streak

### DIFF
--- a/results.py
+++ b/results.py
@@ -1162,12 +1162,14 @@ def _update_command_error_state(
     *,
     now: float,
     spec_name: Optional[str] = None,
+    increment_streak: bool = True,
 ) -> tuple[bool, bool]:
     previous_pause_until = state.paused_until or 0.0
-    state.command_error_streak = min(state.command_error_streak + 1, 10_000)
-    if spec_name:
-        current = state.command_error_streak_by_spec.get(spec_name, 0) + 1
-        state.command_error_streak_by_spec[spec_name] = min(current, 10_000)
+    if increment_streak:
+        state.command_error_streak = min(state.command_error_streak + 1, 10_000)
+        if spec_name:
+            current = state.command_error_streak_by_spec.get(spec_name, 0) + 1
+            state.command_error_streak_by_spec[spec_name] = min(current, 10_000)
 
     pause_active = False
     new_pause_started = False
@@ -2199,7 +2201,10 @@ def _update_once(
                             rate_limits_desc,
                         )
                         _pause_active, new_pause_started = _update_command_error_state(
-                            state, now=current_time, spec_name=spec_name
+                            state,
+                            now=current_time,
+                            spec_name=spec_name,
+                            increment_streak=False,
                         )
                         if new_pause_started:
                             logger.warning(


### PR DESCRIPTION
## Summary
- add an increment flag to `_update_command_error_state` and skip streak updates when a command returns HTTP 429
- adjust 429 handling to use the new flag and leave command error streak and pause state untouched
- refresh the rate-limit related tests to assert streak behaviour and align expectations with the new polling order

## Testing
- pytest tests/test_results.py::test_update_once_applies_pause_after_consecutive_429
- pytest tests/test_results.py::test_update_once_applies_real_pause_after_delayed_429
- pytest tests/test_results.py::test_idle_names_overlay_probe_limits_request_frequency

------
https://chatgpt.com/codex/tasks/task_e_68e26d9e2754832ab3e8b233ac000f23