### PR TITLE
Handle missing overlay availability

### DIFF
--- a/results.py
+++ b/results.py
@@ -638,7 +638,7 @@ def ensure_snapshot_entry(kort_id: str) -> Dict[str, Any]:
                 "raw": {},
                 "serving": None,
                 "error": None,
-                "available": False,
+                "available": None,
                 "archive": [],
                 "pause_active": False,
                 "pause_minutes": COMMAND_ERROR_PAUSE_MINUTES,
@@ -1004,7 +1004,7 @@ def _merge_partial_payload(kort_id: str, partial: Dict[str, Any]) -> Dict[str, A
         entry.setdefault("archive", entry.get("archive", []))
         entry.setdefault("status", SNAPSHOT_STATUS_NO_DATA)
         entry.setdefault("serving", None)
-        entry.setdefault("available", False)
+        entry.setdefault("available", None)
         entry["last_updated"] = _now_iso()
         entry["error"] = None
         entry["pause_minutes"] = entry.get("pause_minutes") or COMMAND_ERROR_PAUSE_MINUTES
@@ -1022,7 +1022,8 @@ def _merge_partial_payload(kort_id: str, partial: Dict[str, Any]) -> Dict[str, A
         players = parsed["players"]
         serving = parsed["serving"]
         available_value = parsed.get("available")
-        entry["available"] = bool(available_value) if available_value is not None else False
+        if available_value is not None:
+            entry["available"] = bool(available_value)
 
         def _has_player_info(info: Any) -> bool:
             if not isinstance(info, dict):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -335,12 +335,25 @@ def test_merge_partial_payload_sets_available_flag(payload, expected):
     assert snapshot["available"] is expected
 
 
-def test_merge_partial_payload_defaults_available_to_false():
+def test_merge_partial_payload_defaults_available_to_none():
     kort_id = "no-visibility"
 
     snapshot = results_module._merge_partial_payload(kort_id, {})
 
-    assert snapshot["available"] is False
+    assert snapshot["available"] is None
+
+
+def test_merge_partial_payload_missing_visibility_keeps_none():
+    kort_id = "no-visibility-unchanged"
+
+    initial_snapshot = results_module._merge_partial_payload(kort_id, {})
+    assert initial_snapshot["available"] is None
+
+    partial = results_module._flatten_overlay_payload({"NamePlayerA": "A. Kowalski"})
+
+    snapshot = results_module._merge_partial_payload(kort_id, partial)
+
+    assert snapshot["available"] is None
 
 
 def test_merge_partial_payload_single_player_payload_sets_partial_status():


### PR DESCRIPTION
## Summary
- default snapshot entries to report no overlay availability until data arrives
- skip overriding the availability field when payloads omit visibility information
- add regression tests ensuring availability remains unset without visibility data

## Testing
- pytest tests/test_results.py -k available

------
https://chatgpt.com/codex/tasks/task_e_68e27a332d44832ab206110b33e18d05