### PR TITLE
Allow phase to advance when scores arrive before name stabilization

### DIFF
--- a/results.py
+++ b/results.py
@@ -1357,13 +1357,6 @@ def _classify_phase(
         return CourtPhase.IDLE_NAMES
 
     if (
-        state.phase is CourtPhase.IDLE_NAMES
-        and NAME_STABILIZATION_TICKS > 0
-        and state.name_stability < NAME_STABILIZATION_TICKS
-    ):
-        return CourtPhase.IDLE_NAMES
-
-    if (
         state.name_stability < NAME_STABILIZATION_TICKS
         and not score.points_any
         and not score.games_any

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -462,6 +462,31 @@ def test_complete_names_trigger_pre_start_within_three_ticks():
     assert schedule.next_due is not None
 
 
+def test_scores_allow_phase_progress_before_name_stabilization():
+    kort_id = "score-before-stable"
+    state = results_module._ensure_court_state(kort_id)
+    state.phase_offset = 0.0
+    state._configure_phase_commands(now=0.0)
+
+    payload = results_module._flatten_overlay_payload(
+        {
+            "NamePlayerA": "A. Kowalski",
+            "NamePlayerB": "B. Zielińska",
+            "PointsPlayerA": 15,
+            "PointsPlayerB": 0,
+        }
+    )
+    snapshot = results_module._merge_partial_payload(kort_id, payload)
+
+    now = 0.0
+    results_module._process_snapshot(state, snapshot, now)
+
+    if results_module.NAME_STABILIZATION_TICKS > 1:
+        assert state.name_stability < results_module.NAME_STABILIZATION_TICKS
+
+    assert state.phase is CourtPhase.PRE_START
+
+
 def test_name_stabilization_triggers_points_schedule_and_snapshot_completion():
     kort_id = "phase-schedule"
     state = results_module._ensure_court_state(kort_id)


### PR DESCRIPTION
## Summary
- remove the early return that forced IDLE_NAMES while waiting for name stabilization
- add coverage proving score data can advance the phase before names are stable

## Testing
- pytest tests/test_results.py -k "phase_progress"


------
https://chatgpt.com/codex/tasks/task_e_68e284f5e568832a8c407618f79864eb