### PR TITLE
Treat name-only overlays as complete snapshots

### DIFF
--- a/results.py
+++ b/results.py
@@ -1101,7 +1101,8 @@ def _merge_partial_payload(kort_id: str, partial: Dict[str, Any]) -> Dict[str, A
                 elif candidate not in (None, ""):
                     name_value = candidate
                     break
-            if not isinstance(name_value, str) or not name_value.strip():
+            has_name = isinstance(name_value, str) and bool(name_value.strip())
+            if not has_name:
                 return False
 
             points_value: Optional[Any] = None
@@ -1131,7 +1132,7 @@ def _merge_partial_payload(kort_id: str, partial: Dict[str, Any]) -> Dict[str, A
                         set_values.append(value)
             has_sets = any(_has_content(value) for value in set_values)
 
-            return has_points or has_sets
+            return has_name or has_points or has_sets
 
         entry["status"] = SNAPSHOT_STATUS_NO_DATA
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -368,7 +368,7 @@ def test_merge_partial_payload_single_player_payload_sets_partial_status():
     assert snapshot["status"] == SNAPSHOT_STATUS_PARTIAL
 
 
-def test_merge_partial_payload_name_only_updates_set_partial_status():
+def test_merge_partial_payload_name_only_updates_set_ok_status():
     kort_id = "name-only"
 
     first = results_module._flatten_overlay_payload({"NamePlayerA": "A. Kowalski"})
@@ -379,7 +379,7 @@ def test_merge_partial_payload_name_only_updates_set_partial_status():
     second = results_module._flatten_overlay_payload({"NamePlayerB": "B. Zielińska"})
     snapshot = results_module._merge_partial_payload(kort_id, second)
 
-    assert snapshot["status"] == SNAPSHOT_STATUS_PARTIAL
+    assert snapshot["status"] == SNAPSHOT_STATUS_OK
 
 
 def test_merge_partial_payload_preserves_existing_name_on_blank_update():
@@ -414,7 +414,7 @@ def test_partial_updates_allow_state_progression():
         now += 1
         results_module._process_snapshot(state, snapshot, now)
 
-    assert snapshot["status"] == SNAPSHOT_STATUS_PARTIAL
+    assert snapshot["status"] == SNAPSHOT_STATUS_OK
     assert state.phase is CourtPhase.PRE_START
 
     third = results_module._flatten_overlay_payload(
@@ -505,7 +505,7 @@ def test_name_stabilization_triggers_points_schedule_and_snapshot_completion():
         now += 1.0
         results_module._process_snapshot(state, snapshot, now)
 
-    assert snapshot["status"] == SNAPSHOT_STATUS_PARTIAL
+    assert snapshot["status"] == SNAPSHOT_STATUS_OK
     assert state.phase is CourtPhase.PRE_START
 
     schedule = state.command_schedules.get("GetPoints")


### PR DESCRIPTION
## Summary
- treat a player payload with a populated name as complete during snapshot merging
- update snapshot tests to mark name-only payloads as OK once both players are known

## Testing
- pytest tests/test_results.py

------
https://chatgpt.com/codex/tasks/task_e_68e28b0ad280832a990a717205b54acf